### PR TITLE
FOLIO-2706 Use FQDN .dev.folio.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # z2folio - the Z39.50-to-FOLIO gateway
 
-Copyright (C) 2018 The Open Library Foundation
+Copyright (C) 2018-2020 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/doc/using-srs.md
+++ b/doc/using-srs.md
@@ -31,7 +31,7 @@ The MARC format also remains important as the principal form in which [Z39.50](h
 
 ## Finding example SRS records
 
-It turns out that there are no SRS reference records, analogous to the reference records that are provided by `mod-inventory-storage` and which therefore turn up on each new build of reference environments such as [folio-snapshot](https://folio-snapshot.aws.indexdata.com/). That is unfortunate: such records would have been easy to work with, and to write test suites around.
+It turns out that there are no SRS reference records, analogous to the reference records that are provided by `mod-inventory-storage` and which therefore turn up on each new build of reference environments such as [folio-snapshot](https://folio-snapshot.dev.folio.org/). That is unfortunate: such records would have been easy to work with, and to write test suites around.
 
 There are specific servers, mostly beonging to customers, that do contain SRS records, but we cannot depend on these to remain in any given state such that tests can be reliably run against them. Similarly, bugfest environments like [bugfest-goldenrod](https://bugfest-goldenrod.folio.ebsco.com/) may contain SRS records, but their content cannot be relied upon to stay constant for tests.
 


### PR DESCRIPTION
This updates one file to use the new domain name for reference environments.

There are two others which i was not clear how to handle, viz:
etc/config.json
lib/Net/Z3950/FOLIO/Config.pod