### PR TITLE
Fix text typos

### DIFF
--- a/bin/z2folio
+++ b/bin/z2folio
@@ -52,7 +52,7 @@ FOLIO ILS.  Because it relies on the C<Net::Z3950::SimpleServer>
 modules for the server functionality, because this module is based on
 the YAZ toolkit, and because YAZ transparently handles all three
 standard IR protocols (ANSI/NISO Z39.50, SRU and SRW), it can function
-as a support all three of these protocols.
+as a support for all three of these protocols.
 
 The following command-line options govern how it functions:
 

--- a/doc/capabilities.md
+++ b/doc/capabilities.md
@@ -24,13 +24,13 @@ The FOLIO Z39.50 server is [a FOLIO module](https://github.com/folio-org/Net-Z39
 
 The server is implemented as a Perl module, [`Net::Z3950::FOLIO`](https://metacpan.org/pod/Net::Z3950::FOLIO), which is available on CPAN (the Perl software repository) like any other Perl module. (Perl was chosen because [the `Net::Z3950::SimpleServer` module](https://metacpan.org/pod/Net::Z3950::SimpleServer) makes it so much easier to implement a Z39.50 server than in other languages.)
 
-The behaviour of the Z39.50 server is driven in part by [a configuration file](from-pod/Net-Z3950-FOLIO-Config.md). The server is distributed with [a standard configuration](../etc/config.json) which specifies things like how to determine what FOLIO servive to access, where to find the GraphQL query that extracts holdings information, and how Z39.50 queries are mapped into the CQL queries that FOLIO uses. It is possible to run the server with a different configuration, but this document describes capabilities such as the supported searches under the assumption that the standard configuration is in user. Standard disclaimers apply.
+The behaviour of the Z39.50 server is driven in part by [a configuration file](from-pod/Net-Z3950-FOLIO-Config.md). The server is distributed with [a standard configuration](../etc/config.json) which specifies things like how to determine what FOLIO service to access, where to find the GraphQL query that extracts holdings information, and how Z39.50 queries are mapped into the CQL queries that FOLIO uses. It is possible to run the server with a different configuration, but this document describes capabilities such as the supported searches under the assumption that the standard configuration is in use. Standard disclaimers apply.
 
 
 
 ## Server deployment
 
-Since the FOLIO Z39.50 server is strictly a client to the rest of FOLIO (it uses `mod-graphql` and `mod-source-record-storage`), it does not need to be installed as a part of FOLIO itself, and can run outside of a FOLIO installation provided it is furnished with the credentials for a user with all necessary permissions. However, it will typically be run as a FOLIO module itself, described by the provided [module descriptor](../ModuleDescriptor.json) and packaged to run as a contained by the provided [Docker file](../Dockerfile) (see [below](#running-under-docker)).
+Since the FOLIO Z39.50 server is strictly a client to the rest of FOLIO (it uses `mod-graphql` and `mod-source-record-storage`), it does not need to be installed as a part of FOLIO itself, and can run outside of a FOLIO installation provided it is furnished with the credentials for a user with all necessary permissions. However, it will typically be run as a FOLIO module itself, described by the provided [module descriptor](../ModuleDescriptor.json) and packaged to run as a container by the provided [Docker file](../Dockerfile) (see [below](#running-under-docker)).
 
 When using the standard configuration file (see above), it is necessary to provide four pieces of information as environment variables:
 
@@ -99,7 +99,7 @@ services are not supported by the underlying SimpleServer library, so there is n
 
 ### Z39.50 authentication
 
-If no default username and password are specified in the server's configuration, or if the user has reason to want to authenticate onto FOLIO as a differet user, these tokens can be provided in the Z39.50 Init request as a single "open" authentication string, separated by a forward slash (`/`). (In the YAZ command-line clientw, this can be done using the command `auth user/pass`. If authentication onto FOLIO is rejected &mdash; because of incorrect tokens or for any other reason &mdash; the Z39.50 server will reject the Init request, with the response including a diagnostic `otherInfo` unit.
+If no default username and password are specified in the server's configuration, or if the user has reason to want to authenticate onto FOLIO as a different user, these tokens can be provided in the Z39.50 Init request as a single "open" authentication string, separated by a forward slash (`/`). (In the YAZ command-line client, this can be done using the command `auth user/pass`. If authentication onto FOLIO is rejected &mdash; because of incorrect tokens or for any other reason &mdash; the Z39.50 server will reject the Init request, with the response including a diagnostic `otherInfo` unit.
 
 Here's how that looks using the YAZ command-line client:
 
@@ -124,9 +124,9 @@ Here's how that looks using the YAZ command-line client:
 	Name   : z2folio gateway/GFS/YAZ
 	Version: 1.2/5.30.3 2af59bc45cf4508d5c84f350ee99804c4354b3b3
 	Options: search present delSet triggerResourceCtrl sort namedResultSets
-	Z> 
+	Z>
 
-Usually, the Z39.50 server will be configured to default to logging in as a specied user (see the discussion of `OKAPI_USER` and `OKAPI_PASSWORD` [above](#server-deployment)).
+Usually, the Z39.50 server will be configured to default to logging in as a specified user (see the discussion of `OKAPI_USER` and `OKAPI_PASSWORD` [above](#server-deployment)).
 
 
 ### Z39.50 searching
@@ -179,7 +179,7 @@ The following truncation attributes (type 5) are supported:
 * **2.** Left truncation
 * **3.** Left and right
 * **100.** Do not truncate
-* **101.** Process # in search trm
+* **101.** Process # in search term
 * **104.** Z39.58 (CCL-style masking)
 
 The following completeness attributes (type 6) are supported:
@@ -212,24 +212,24 @@ The Z39.50 Sort service is supported as follows:
 * Only one result-set can be sorted at once, i.e. the service cannot be used to merge multiple result sets.
 * "Generic" sorting is supported; "database-specific" sorting is not.
 * Within each sort key:
-  * Sort-fields can be specified as a sort-attribute of type 1 (use attribute) with value coresponding to the field to sort on. These values are the same as for use attributes when searching.
+  * Sort-fields can be specified as a sort-attribute of type 1 (use attribute) with value corresponding to the field to sort on. These values are the same as for use attributes when searching.
   * Relations 0 (ascending) and 1 (descending) are supported. Relations 3 (ascending by frequency) and 4 (descending by frequency) are not.
   * Cases 0 (case-sensitive) and 1 (case-insensitive) are supported.
   * Missing-value specifications 1 (fail) and 2 (null value) are supported. Value 3 (treat missing as a specified value) is not.
 
 So, for example, the YAZ command-line client comment `sort 1=4 s< 1=21 i>` will sort first by title, case-insensitively in ascending order, then by HRID, case-sensitively in descending order.
 
-**NOTE.** As with searching, "support" here means that the Z39.50 server generates the correct CQL query to express the Z39.50 query using these attributes: the FOLIO back-end does not necessarily support all the CQL queries. Where a given index does not support some of the sort-index modifiers that it ought, these can be explicily omitted using [the `omitSortIndexModifiers` configuration option](from-pod/Net-Z3950-FOLIO-Config.md#omitSortIndexModifiers).
+**NOTE.** As with searching, "support" here means that the Z39.50 server generates the correct CQL query to express the Z39.50 query using these attributes: the FOLIO back-end does not necessarily support all the CQL queries. Where a given index does not support some of the sort-index modifiers that it ought, these can be explicitly omitted using [the `omitSortIndexModifiers` configuration option](from-pod/Net-Z3950-FOLIO-Config.md#omitSortIndexModifiers).
 
 
 
 ## SRU
 
-[The SRU standard](https://www.loc.gov/standards/sru/) is a recasting of Z39.50-like semantics into a more web-friendly format, in which requests are expressed as HTTP URLs with specific query parameters, and responses are XML documents. Unlike Z39.50, it is stateless: each request is self-contained and does not depend on earlier operations. As a result, it has no concept of session initialization, and no result sets: each request is its own search and immedately returns the relevant records. A typical SRU request looks like this:
+[The SRU standard](https://www.loc.gov/standards/sru/) is a recasting of Z39.50-like semantics into a more web-friendly format, in which requests are expressed as HTTP URLs with specific query parameters, and responses are XML documents. Unlike Z39.50, it is stateless: each request is self-contained and does not depend on earlier operations. As a result, it has no concept of session initialization, and no result sets: each request is its own search and immediately returns the relevant records. A typical SRU request looks like this:
 
 http://lehigh-z3950-test.folio.indexdata.com:9997/sru/TEST?version=1.1&operation=searchRetrieve&query=title=a&maximumRecords=1&recordSchema=opac
 
-When building new clients to integrate with this server, SRU may be easier to use than Z39.50 because it is defined as in terms of XML and HTTP, a format and protocol for which there are many libriaries available in many languages.
+When building new clients to integrate with this server, SRU may be easier to use than Z39.50 because it is defined as in terms of XML and HTTP, a format and protocol for which there are many libraries available in many languages.
 
 
 ### SRU authentication
@@ -243,7 +243,7 @@ http://lehigh-z3950-test.folio.indexdata.com:9997/sru/TEST?version=1.1&operation
 
 ### SRU searching
 
-In SRU, the query is expressed is CQL, the same query language that FOLIO uses internally. The FOLIO SRU server therefore passes the query straight through to the back-end, and all CQL queries that work in FOLIO's inventory instances store will work in CQL. (The `indexMap` part of the configuration file is therefore not used when serving SRU requests.)
+In SRU, the query is expressed as CQL, the same query language that FOLIO uses internally. The FOLIO SRU server therefore passes the query straight through to the back-end, and all CQL queries that work in FOLIO's inventory instances store will work in CQL. (The `indexMap` part of the configuration file is therefore not used when serving SRU requests.)
 
 To see some of the CQL searches that are supported on the FOLIO back-end, see the values corresponding to the BIB-1 use attributes in the `indexMap` part of [the standard configuration](../etc/config.json): for example, `item.barcode=14120137` can be used to search for bibliographic records of instances that have an item with the specific barcode.
 

--- a/doc/release-procedure.md
+++ b/doc/release-procedure.md
@@ -9,7 +9,7 @@ Since this Z39.50 server is written as a Perl module, it adheres to Perl release
 
 * Formal releases are made via [CPAN](https://www.cpan.org/), the Comprehensive Perl Archive Network rather than via NPM or a Maven repository.
 
-* The master version number is held in the source-code itself -- specificially in [`Net/Z3950/FOLIO.pm`](../lib/Net/Z3950/FOLIO.pm) -- and is extracted by the package-building code invoked from [`Makefile.PL`](../Makefile.PL).
+* The master version number is held in the source-code itself -- specifically in [`Net/Z3950/FOLIO.pm`](../lib/Net/Z3950/FOLIO.pm) -- and is extracted by the package-building code invoked from [`Makefile.PL`](../Makefile.PL).
 
 * The change-log is [`Changes.md`](../Changes.md) rather than `CHANGELOG.md` or `NEWS.md`.
 

--- a/doc/source-code-overview.md
+++ b/doc/source-code-overview.md
@@ -15,7 +15,7 @@
 
 ## Introduction
 
-The FOLIO Z39.50 server is written in Perl, due to that language's excellent support for the Z39.50 protocol and particlarly [the `SimpleServer` module](https://metacpan.org/pod/Net::Z3950::SimpleServer).
+The FOLIO Z39.50 server is written in Perl, due to that language's excellent support for the Z39.50 protocol and particularly [the `SimpleServer` module](https://metacpan.org/pod/Net::Z3950::SimpleServer).
 
 The source code consists of three sets of files:
 
@@ -41,7 +41,7 @@ The top-level server class. [The public API](from-pod/Net-Z3950-FOLIO.md) consis
 
 The SimpleServer API provides two handles which can be initialized by constructors and handler functions, and which are passed back as part of the argument block given to every handler function. These are the global handle, called GHANDLE, and the session handle, just called HANDLE. The former is set in the constructor, and used as a pointer to the `Net::Z3950::FOLIO` server object itself. The latter is set in the search handler (see below), and points to the session object on which the search is invoked.
 
-Conceptually, sessions should be created by the init handler, but in the Z39.50 protocol the name of the database to be searched is not specified until a search is issued, so there is no name by which the session can be known at init-time. Since the database name is also used to determine which set on configuration files to load for the session, this too must be deferred until search time: the response to the Z39.50 init request, then, is fairly vacuous: all it says that the server is ready to receive searches -- but only when the first search comes in can the configuration be loaded.
+Conceptually, sessions should be created by the init handler, but in the Z39.50 protocol the name of the database to be searched is not specified until a search is issued, so there is no name by which the session can be known at init-time. Since the database name is also used to determine which set of configuration files to load for the session, this too must be deferred until search time: the response to the Z39.50 init request, then, is fairly vacuous: all it says that the server is ready to receive searches -- but only when the first search comes in can the configuration be loaded.
 
 
 ### `lib/Net/Z3950/FOLIO/Session.pm`

--- a/doc/srs/using-srs.md
+++ b/doc/srs/using-srs.md
@@ -20,20 +20,20 @@ module. `mod-inventory-storage` defines the FOLIO inventory formats: one each fo
 and
 [item records](https://github.com/folio-org/mod-inventory-storage/blob/master/ramls/item.json).
 
-However, many libraries remain wedded to [MARC records](https://en.wikipedia.org/wiki/MARC_standards), a standard from the 1960s that has comfortably outlives many of the citics who have pronounced its death over the years. FOLIO therefore provides a Source Record Storage (SRS) facility. Using this, MARC records may be uploaded to a FOLIO service. When this upload is performed using
+However, many libraries remain wedded to [MARC records](https://en.wikipedia.org/wiki/MARC_standards), a standard from the 1960s that has comfortably outlives many of the critics who have pronounced its death over the years. FOLIO therefore provides a Source Record Storage (SRS) facility. Using this, MARC records may be uploaded to a FOLIO service. When this upload is performed using
 [`mod-data-import`](https://github.com/folio-org/mod-data-import),
-the records are automatically converted into instance records which are inked to the source records -- the latter being retained by the system and remaining the version of record.
+the records are automatically converted into instance records which are linked to the source records -- the latter being retained by the system and remaining the version of record.
 
 The MARC format also remains important as the principal form in which [Z39.50](https://en.wikipedia.org/wiki/Z39.50) servers provide records to clients. [The FOLIO Z39.50 server](https://github.com/folio-org/Net-Z3950-FOLIO) can return XML records that are a transliteration of the JSON format for instances, but it is also required to serve MARC records -- for example, so it can provide relevant information to ILL systems.
 
-[Issue ZF-05](https://issues.folio.org/browse/ZF-5) is to extend the Z93.50 server so that, when MARC records are requested, the server fetches the relevant records from SRS and returns them. To do this, it's necessary to locate a back-end service with sample SRS records, or create some; and to have the Z39.50 server issue requests to the SRS WSAPI. Both these steps are non-trivial.
+[Issue ZF-05](https://issues.folio.org/browse/ZF-5) is to extend the Z39.50 server so that, when MARC records are requested, the server fetches the relevant records from SRS and returns them. To do this, it's necessary to locate a back-end service with sample SRS records, or create some; and to have the Z39.50 server issue requests to the SRS WSAPI. Both these steps are non-trivial.
 
 
 ## Finding example SRS records
 
 It turns out that there are no SRS reference records, analogous to the reference records that are provided by `mod-inventory-storage` and which therefore turn up on each new build of reference environments such as [folio-snapshot](https://folio-snapshot.dev.folio.org/). That is unfortunate: such records would have been easy to work with, and to write test suites around.
 
-There are specific servers, mostly beonging to customers, that do contain SRS records, but we cannot depend on these to remain in any given state such that tests can be reliably run against them. Similarly, bugfest environments like [bugfest-goldenrod](https://bugfest-goldenrod.folio.ebsco.com/) may contain SRS records, but their content cannot be relied upon to stay constant for tests.
+There are specific servers, mostly belonging to customers, that do contain SRS records, but we cannot depend on these to remain in any given state such that tests can be reliably run against them. Similarly, bugfest environments like [bugfest-goldenrod](https://bugfest-goldenrod.folio.ebsco.com/) may contain SRS records, but their content cannot be relied upon to stay constant for tests.
 
 As a result, it seems we have little option but to obtain a set of MARC records and insert them into a reference environment ourselves. (Or perhaps once such records exist, they could fairly easily be added as reference data to
 [`mod-source-record-storage`](https://github.com/folio-org/mod-source-record-storage)
@@ -150,7 +150,7 @@ I have no idea why the front-end would care about any of this.
 
 7. GET `/data-import-profiles/jobProfiles` with `limit` 5000 and query `(dataType==("MARC")) sortby name`, also yielding an empty list.
 
-At this point, network request cease until you choose **Load MARC bibliographic records** from the **Actions** button to top left. Then the following further operations happen:
+At this point, network requests cease until you choose **Load MARC bibliographic records** from the **Actions** button to top left. Then the following further operations happen:
 
 8. GET `https://folio-snapshot-okapi.dev.folio.org/data-import/uploadDefinitions/83447cac-8dfc-45fa-8c70-a34f7082c57d`
 ```

--- a/lib/Net/Z3950/FOLIO/Config.pm
+++ b/lib/Net/Z3950/FOLIO/Config.pm
@@ -340,11 +340,11 @@ To implement both multi-tenancy and per-database output tweaks that may be requi
 
 =item 1
 
-A base configuration file is always used, and will typically provide the bulk of the configuraiton that is the same for all supported tenants and filters. Its base name is specified when the server is invoked -- for example, as the argument to the C<-c> command-line option of C<z2folio>: when the server is invoked as C<z2folio -c etc/config> the base configuration file is found at C<etc/config.json>.
+A base configuration file is always used, and will typically provide the bulk of the configuration that is the same for all supported tenants and filters. Its base name is specified when the server is invoked -- for example, as the argument to the C<-c> command-line option of C<z2folio>: when the server is invoked as C<z2folio -c etc/config> the base configuration file is found at C<etc/config.json>.
 
 =item 2
 
-The Z39.50 database name provided in a search is used as a name of a sub-configuration specific to that database, and is also passed to FOLIO as the name of the tenant to be addressed. So for example, if a Z93.50 search request come in for the database C<theo>, then the additional tenant-specific configuration file C<etc/config.theo.json> is also consulted. It is acceptable for the file not to exist, in which case there is no tenant-specific configuration and the base configuration is used for that database.
+The Z39.50 database name provided in a search is used as a name of a sub-configuration specific to that database, and is also passed to FOLIO as the name of the tenant to be addressed. So for example, if a Z39.50 search request come in for the database C<theo>, then the additional tenant-specific configuration file C<etc/config.theo.json> is also consulted. It is acceptable for the file not to exist, in which case there is no tenant-specific configuration and the base configuration is used for that database.
 
 Values provided in a tenant-specific configuration are added to those of the base configuration, overriding the base values when the same item is provided at both levels.
 


### PR DESCRIPTION
Note that i have not run 'make' in doc/from-pod as i do not have pod2markdown.
