### PR TITLE
Remove default query filter

### DIFF
--- a/etc/config.json
+++ b/etc/config.json
@@ -23,6 +23,5 @@
     "9999": "contributors/@name,title,hrid,subjects"
   },
   "graphqlQuery": "instances.graphql-query",
-  "queryFilter": "source=marc",
   "chunkSize": 5
 }


### PR DESCRIPTION
Not every FOLIO has marc records (folio-testing/snapshot for example).