### PR TITLE
Remove materialType (for now?)

### DIFF
--- a/etc/instances.graphql-query
+++ b/etc/instances.graphql-query
@@ -99,11 +99,6 @@ query($cql: String, $offset: Int, $limit: Int) {
           itemLevelCallNumberSuffix
           itemLevelCallNumberTypeId
           materialTypeId
-          materialType {
-            id
-            name
-            source
-          }
           metadata {
             createdByUserId
             createdByUsername


### PR DESCRIPTION
Tested it with folio-testing/snapshot and got following error. It could be that the mod-graphql on those sites are not up to date with mod-inventory-storage RAML, or could be something else.
Diagnostic message(s) from database:
    [3] Unsupported search -- v2 addinfo 'Cannot query field "materialType" on type "T_item". Did you mean "materialTypeId"?'