### PR TITLE
remove custom UUID field 7 chicago config

### DIFF
--- a/etc/config.chicago.json
+++ b/etc/config.chicago.json
@@ -6,8 +6,5 @@
   "login": {
     "username": "${OKAPI_USER-uchicago_admin}",
     "password": "${OKAPI_CHICAGO_PASSWORD}"
-  },
-  "indexMap": {
-    "7": "identifiers/@value/@identifierTypeId=\"cf0a2485-22e9-5be4-ac5c-fe393fb964e4\""
   }
 }


### PR DESCRIPTION
@MikeTaylor updates the config example to remove custom UUID override. Nice to know its an option but no longer needed for Chicago I understand.