### PR TITLE
ZF-51: /usr/lib/apt/methods/https could not be found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN cpan MARC::Record
 RUN cpan Net::Z3950::PQF
 RUN cpan Unicode::Diacritic::Strip
 RUN apt-get update
-RUN apt-get -y install software-properties-common
+RUN apt-get -y install software-properties-common apt-transport-https ca-certificates
 RUN wget http://ftp.indexdata.dk/debian/indexdata.asc
 RUN apt-key add indexdata.asc
 RUN add-apt-repository 'deb http://ftp.indexdata.dk/debian jessie main'


### PR DESCRIPTION
Do

apt-get install apt-transport-https ca-certificates

to fix this docker build error:

Step 18/23 : RUN apt-get update
 ---> Running in 89a6da6fd1d1
Hit http://security.debian.org jessie/updates InRelease
Ign http://httpredir.debian.org jessie InRelease
Hit http://httpredir.debian.org jessie-updates InRelease
E: The method driver /usr/lib/apt/methods/https could not be found.
The command '/bin/sh -c apt-get update' returned a non-zero code: 100