### PR TITLE
Point to the bullseye distro in the ID Apt repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update
 RUN apt-get -y install software-properties-common apt-transport-https ca-certificates
 RUN wget http://ftp.indexdata.dk/debian/indexdata.asc
 RUN apt-key add indexdata.asc
-RUN add-apt-repository 'deb http://ftp.indexdata.dk/debian jessie main'
+RUN add-apt-repository 'deb http://ftp.indexdata.dk/debian bullseye main'
 RUN apt-get update
 RUN apt-get -y install yaz libyaz5-dev
 RUN cpan -T -f Net::Z3950::ZOOM # Tests are very very slow AND sometimes time out


### PR DESCRIPTION
Now that the Perl 5.30 distro is using Debian Bullseye, we need to install yaz from the Bullseye Index Data apt repo. 