### PR TITLE
MARC holdings can now be field-per-item as well as field-per-holding

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,9 +1,10 @@
 # Revision history for Perl extension Net::Z3950::FOLIO.
 
-## [In progress](https://github.com/folio-org/Net-Z3950-FOLIO/tree/master)
+## [IN PROGRESS]
 
 * Loosen requirements for `search` interface to allow v0.7. Fixes ZF-71.
 * Restructure Dockerfile to be more efficient and reliable. Fixes ZF-72.
+* New `fieldPerItem` configuration entry allows each item to be placed in its own MARC holdings field rather than each item in a holding sharing the field. Fixes ZF-74.
 
 ## [3.1.0](https://github.com/folio-org/Net-Z3950-FOLIO/tree/v3.1.0) (Sun Nov 27 08:36:08 GMT 2022)
 

--- a/doc/from-pod/Net-Z3950-FOLIO-Config.md
+++ b/doc/from-pod/Net-Z3950-FOLIO-Config.md
@@ -233,6 +233,18 @@ be mapped into MARC fields. It contains up to five elements:
 
     information.
 
+- `fieldPerItem`
+
+    If specified and set to a true value, then a separate MARC field is
+    generated for each item in each holding. When this is absent or set to
+    a false value (the default), one MARC field is generated for each
+    holding, and multiple items within each holding are represented by
+    repeating sets of subfields within that field.
+
+    This setting makes it simpler to access information about individual
+    items, at the cost of losing information about how they are grouped
+    into holdings.
+
 - `holdingsElements`
 
     An object specifying MARC subfields that should be set from

--- a/etc/config.fieldPerItem.json
+++ b/etc/config.fieldPerItem.json
@@ -1,0 +1,5 @@
+{
+  "marcHoldings": {
+    "fieldPerItem": true
+  }
+}

--- a/lib/Net/Z3950/FOLIO/Config.pm
+++ b/lib/Net/Z3950/FOLIO/Config.pm
@@ -413,6 +413,18 @@ be specified as a single space.
 
 information.
 
+=item C<fieldPerItem>
+
+If specified and set to a true value, then a separate MARC field is
+generated for each item in each holding. When this is absent or set to
+a false value (the default), one MARC field is generated for each
+holding, and multiple items within each holding are represented by
+repeating sets of subfields within that field.
+
+This setting makes it simpler to access information about individual
+items, at the cost of losing information about how they are grouped
+into holdings.
+
 =item C<holdingsElements>
 
 An object specifying MARC subfields that should be set from

--- a/lib/Net/Z3950/FOLIO/Config.pm
+++ b/lib/Net/Z3950/FOLIO/Config.pm
@@ -93,10 +93,13 @@ sub _expandSingleVariableReference {
 	return _expandVariableReferences($val);
     } elsif (ref($val) eq 'ARRAY') {
 	return [ map { _expandSingleVariableReference($key, $_) } @$val ];
+    } elsif (ref($val) eq 'JSON::PP::Boolean') {
+	return $val;
     } elsif (!ref($val)) {
 	return _expandScalarVariableReference($key, $val);
     } else {
-	die "non-hash, non-array, non-scalar configuration key '$key'";
+	use Data::Dumper;
+	die "non-hash, non-array, non-boolean, non-scalar configuration key '$key' = ", Dumper($val);
     }
 }
 
@@ -131,7 +134,7 @@ sub _expandScalarVariableReference {
 sub _mergeConfig {
     my($base, $overlay) = @_;
 
-    my @known_keys = qw(okapi login indexMap);
+    my @known_keys = qw(okapi login indexMap marcHoldings);
     foreach my $key (@known_keys) {
 	if (defined $overlay->{$key}) {
 	    if (ref $base->{$key} eq 'HASH') {

--- a/lib/Net/Z3950/FOLIO/MARCHoldings.pm
+++ b/lib/Net/Z3950/FOLIO/MARCHoldings.pm
@@ -26,6 +26,10 @@ sub insertMARCHoldings {
 	    for (my $j = 0; $j < @$itemObjects; $j++) {
 		my $itemMap = _listOfPairs2map($itemObjects->[$j]);
 		$marcField = _addSubfields($marcField, $marcCfg, $marcCfg->{itemElements}, $itemMap);
+		if ($marcCfg->{fieldPerItem} && $marcField) {
+		    $marc->append_fields($marcField);
+		    $marcField = undef;
+		}
 	    }
 	}
 

--- a/t/04-stacking-config.t
+++ b/t/04-stacking-config.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 14;
+use Test::More tests => 20;
 BEGIN { use_ok('Net::Z3950::FOLIO::Config') };
 
 my $cfg = new Net::Z3950::FOLIO::Config('t/data/config/foo', 'bar');
@@ -19,3 +19,13 @@ is($cfg->{foo}, 42, "Base value, not overriden");
 is($cfg->{bar}, 4, "Overridden in first override");
 is($cfg->{baz}, 'thricken', "Overridden in second override");
 is($cfg->{quux}, 99, "Present only in second override");
+
+$cfg = new Net::Z3950::FOLIO::Config('t/data/config/foo', 'marcHoldings');
+ok(defined $cfg, 'parsed stacked foo->marcHoldings config');
+is($cfg->{marcHoldings}->{field}, "952", "Base value, not overriden");
+is($cfg->{marcHoldings}->{fieldPerItem}, undef, "Absent base value");
+
+$cfg = new Net::Z3950::FOLIO::Config('t/data/config/foo', 'marcHoldings', 'fieldPerItem');
+ok(defined $cfg, 'parsed stacked foo->marcHoldings->fieldPerItem config');
+is($cfg->{marcHoldings}->{field}, "952", "Base value, not overriden");
+is($cfg->{marcHoldings}->{fieldPerItem}, 1, "fieldPerItem overriden");

--- a/t/06-marc-holdings.t
+++ b/t/06-marc-holdings.t
@@ -6,24 +6,25 @@ use warnings;
 use IO::File;
 use MARC::Record;
 use Cpanel::JSON::XS qw(decode_json);
-use Test::More tests => 2;
+use Test::More tests => 3;
 BEGIN { use_ok('Net::Z3950::FOLIO') };
 use Net::Z3950::FOLIO::MARCHoldings qw(insertMARCHoldings);
 use DummyRecord;
 
-my $cfg = new Net::Z3950::FOLIO::Config('t/data/config/foo.marcHoldings');
-
-# Values taken from some random USMARC record
-my $dummyMarc = makeDummyMarc();
-
 for (my $i = 1; $i <= 1; $i++) {
-    my $expected = readFile("t/data/records/expectedMarc$i.marc");
-    my $folioJson = readFile("t/data/records/input$i.json");
-    my $folioHoldings = decode_json(qq[{ "holdingsRecords2": [ $folioJson ] }]);
-    my $rec = new DummyRecord($folioHoldings, $dummyMarc);
-    insertMARCHoldings($rec, $dummyMarc, $cfg);
-    my $marcString = $dummyMarc->as_formatted() . "\n";
-    is($marcString, $expected, "generated holdings $i match expected MARC");
+    for (my $j = 1; $j <= 2; $j++) {
+	my $cfg = new Net::Z3950::FOLIO::Config('t/data/config/foo', 'marcHoldings',
+						$j == 2 ? 'fieldPerItem' : undef);
+	#use Data::Dumper; $Data::Dumper::INDENT = 2; warn "j=$j, config", Dumper($cfg);
+	my $dummyMarc = makeDummyMarc();
+	my $expected = readFile("t/data/records/expectedMarc$i" . ($j == 2 ? 'byItem' : '') . ".marc");
+	my $folioJson = readFile("t/data/records/input$i.json");
+	my $folioHoldings = decode_json(qq[{ "holdingsRecords2": [ $folioJson ] }]);
+	my $rec = new DummyRecord($folioHoldings, $dummyMarc);
+	insertMARCHoldings($rec, $dummyMarc, $cfg);
+	my $marcString = $dummyMarc->as_formatted() . "\n";
+	is($marcString, $expected, "generated holdings $i match expected MARC");
+    }
 }
 
 

--- a/t/data/config/foo.fieldPerItem.json
+++ b/t/data/config/foo.fieldPerItem.json
@@ -1,0 +1,5 @@
+{
+  "marcHoldings": {
+    "fieldPerItem": true
+  }
+}

--- a/t/data/records/expectedMarc1.marc
+++ b/t/data/records/expectedMarc1.marc
@@ -13,3 +13,6 @@ LDR 03101cam a2200505Ii 4500
        _mabc
        _v1
        _ya, b
+       _b9876543210
+       _cMarch
+       _e3

--- a/t/data/records/expectedMarc1byItem.marc
+++ b/t/data/records/expectedMarc1byItem.marc
@@ -1,0 +1,18 @@
+LDR 03101cam a2200505Ii 4500
+007     cr cnu---unuuu
+008     1234567890123456789012345678901
+845    _3Bituminous Coal Division and National Bituminous Coal Commission Records
+       _a"No information obtained from a producer disclosing cost of production or sales realization shall be made public without the consent of the producer from whom the same shall have been obtained";
+       _c50 Stat.88.
+952    _t3
+       _b01234567890
+       _c29
+       _e42
+       _hHD1131.S860 1989
+       _k123
+       _mabc
+       _v1
+       _ya, b
+952    _b9876543210
+       _cMarch
+       _e3

--- a/t/data/records/expectedOutput1.xml
+++ b/t/data/records/expectedOutput1.xml
@@ -39,6 +39,13 @@
           <enumAndChron>42 29</enumAndChron>
           <temporaryLocation>Online Library Resources</temporaryLocation>
         </circulation>
+        <circulation>
+          <availableNow value="0" />
+          <itemId>9876543210</itemId>
+          <renewable value="" />
+          <onHold value="" />
+          <enumAndChron>3 March</enumAndChron>
+        </circulation>
       </circulations>
     </holding>
   </holdings>

--- a/t/data/records/input1.json
+++ b/t/data/records/input1.json
@@ -127,6 +127,61 @@
       },
       "volume": "1",
       "yearCaption": ["a", "b"]
+    },
+    {
+      "accessionNumber": null,
+      "barcode": "9876543210",
+      "chronology": "March",
+      "copyNumber": "1",
+      "descriptionOfPieces": null,
+      "discoverySuppress": true,
+      "electronicAccess": [
+        {
+          "linkText": null,
+          "materialsSpecification": null,
+          "publicNote": "Access E-Book",
+          "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+          "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
+        }
+      ],
+      "enumeration": "3",
+      "formerIds": [],
+      "hrid": "i2036897",
+      "id": "69746298-a428-11ea-b7fc-94e55e224816",
+      "inTransitDestinationServicePointId": null,
+      "itemDamagedStatusDate": null,
+      "itemDamagedStatusId": null,
+      "itemIdentifier": null,
+      "itemLevelCallNumber": "G1046.C3 .L56 2009eb",
+      "itemLevelCallNumberPrefix": null,
+      "itemLevelCallNumberSuffix": null,
+      "itemLevelCallNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+      "metadata": null,
+      "missingPieces": null,
+      "missingPiecesDate": null,
+      "notes": [
+        {
+          "itemNoteType": {
+            "id": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+            "name": "Note",
+            "source": "folio"
+          },
+          "itemNoteTypeId": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+          "note": "Online",
+          "staffOnly": false
+        }
+      ],
+      "numberOfMissingPieces": null,
+      "numberOfPieces": null,
+      "permanentLocationId": null,
+      "statisticalCodeIds": [],
+      "status": {
+        "name": "Available"
+      },
+      "temporaryLoanTypeId": null,
+      "temporaryLocationId": null,
+      "volume": "",
+      "yearCaption": []
     }
   ],
   "holdingsStatements": [],


### PR DESCRIPTION
When the configuration setting `marcHoldings.fieldPerItem` is present and true, each item represented in the MARC record is placed in its own instance of the specified field, rather than (the default) items in a given holding grouped together in an instance of the field that represents the entire holding.

This setting makes it simpler to access information about individual items, at the cost of losing information about how they are grouped into holdings.

Includes documentation and tests.

Fixes ZF-74.