### PR TITLE
Reinstate error-reporting for GraphQL errors

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,10 +1,11 @@
 # Revision history for Perl extension Net::Z3950::FOLIO.
 
-## [IN PROGRESS]
+## 3.2.0 (IN PROGRESS)
 
 * Loosen requirements for `search` interface to allow v0.7. Fixes ZF-71.
 * Restructure Dockerfile to be more efficient and reliable. Fixes ZF-72.
 * New `fieldPerItem` configuration entry allows each item to be placed in its own MARC holdings field rather than each item in a holding sharing the field. Fixes ZF-74.
+* Reinstate error-reporting for GraphQL errors (it seems that the way these are reported in the WSAPI response has changed). Fixes ZF-75.
 
 ## [3.1.0](https://github.com/folio-org/Net-Z3950-FOLIO/tree/v3.1.0) (Sun Nov 27 08:36:08 GMT 2022)
 

--- a/lib/Net/Z3950/FOLIO/Session.pm
+++ b/lib/Net/Z3950/FOLIO/Session.pm
@@ -107,12 +107,11 @@ sub doSearch {
 
     my $obj = decode_json($res->content());
     # warn "result: ", Net::Z3950::FOLIO::Record::_formatJSON($obj);
+    my $errors = $obj->{errors};
+    _throw(1, join(', ', map { $_->{message} } @$errors)) if $errors;
     my $data = $obj->{data} or _throw(1, "no data in response");
-    my $isi = ($data->{search_instances} ||
-	       $data->{instance_storage_instances});
+    my $isi = ($data->{search_instances} || $data->{instance_storage_instances});
     if (!$isi) {
-	my $errors = $obj->{errors};
-	_throw(1, join(', ', map { $_->{message} } @$errors)) if $errors;
 	_throw(1, "no instance_storage_instances in response data " . $res->content());
     }
     $rs->totalCount($isi->{totalRecords} + 0);


### PR DESCRIPTION
It seems that the way these are reported in the WSAPI response has changed.

Fixes ZF-75.