### PR TITLE
ZF-73: Switch base image from perl:5 to perl:5-slim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /Makefile
+.git
 MYMETA.json
 MYMETA.yml
 ModuleDescriptor.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /Makefile
-.git
 MYMETA.json
 MYMETA.yml
 ModuleDescriptor.json

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@
 * Restructure Dockerfile to be more efficient and reliable. Fixes ZF-72.
 * New `fieldPerItem` configuration entry allows each item to be placed in its own MARC holdings field rather than each item in a holding sharing the field. Fixes ZF-74.
 * Reinstate error-reporting for GraphQL errors (it seems that the way these are reported in the WSAPI response has changed). Fixes ZF-75.
+* Switch base image from perl:5 to perl:5-slim. Use signed-by in indexdata.asc for apt. Fixes ZF-73.
 
 ## [3.1.0](https://github.com/folio-org/Net-Z3950-FOLIO/tree/v3.1.0) (Sun Nov 27 08:36:08 GMT 2022)
 

--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,7 @@
 * Restructure Dockerfile to be more efficient and reliable. Fixes ZF-72.
 * New `fieldPerItem` configuration entry allows each item to be placed in its own MARC holdings field rather than each item in a holding sharing the field. Fixes ZF-74.
 * Reinstate error-reporting for GraphQL errors (it seems that the way these are reported in the WSAPI response has changed). Fixes ZF-75.
-* Switch base image from perl:5 to perl:5-slim. Use signed-by in indexdata.asc for apt. Fixes ZF-73.
+* Switch base image from perl:5 to perl:5-slim. Use signed-by indexdata.asc for apt. Fixes ZF-73.
 
 ## [3.1.0](https://github.com/folio-org/Net-Z3950-FOLIO/tree/v3.1.0) (Sun Nov 27 08:36:08 GMT 2022)
 


### PR DESCRIPTION
Switching the base image from per:5 to perl:5-slim reduces the compressed base image size from 322 MB to 53 MB: https://hub.docker.com/_/perl/tags

Not installing unnecessary packages is best practice to reduce complexity, dependencies, file sizes, and build times: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#dont-install-unnecessary-packages

Some required packages are not in perl:5-slim, though. Additional install steps for them are needed in the Dockerfile.

Autoremove and purge build dependencies in the same RUN command to reduce the layer size as recommended by RUN and apt-get best practices: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run

Use signed-by in /etc/apt/sources.list.d/indexdata.list to fix the privilege escalation of indexdata.asc.