### PR TITLE
Omit literal '\n' between <holding>s in OPAC XML record

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@
 * Reinstate error-reporting for GraphQL errors (it seems that the way these are reported in the WSAPI response has changed). Fixes ZF-75.
 * Switch base image from perl:5 to perl:5-slim. Use signed-by indexdata.asc for apt. Fixes ZF-73.
 * Update definitions of access-points 7, 8 and 1211 (ISBN, ISSN and OCLC Number) for mod-search. Fixes ZF-77.
+* Remove literal '\n' sequence from between consecutive `<holding>` entries in OPAC XML records. Fixes ZF-78.
 
 ## [3.1.0](https://github.com/folio-org/Net-Z3950-FOLIO/tree/v3.1.0) (Sun Nov 27 08:36:08 GMT 2022)
 

--- a/lib/Net/Z3950/FOLIO/OPACXMLRecord.pm
+++ b/lib/Net/Z3950/FOLIO/OPACXMLRecord.pm
@@ -51,7 +51,7 @@ sub _resolveHoldingsToXML {
     }
 
     my @holdingsXML = map { _makeXMLElement(4, 'holding', @$_) } @$holdingsObjects;
-    return join('\n', @holdingsXML);
+    return join('', @holdingsXML);
 }
 
 

--- a/t/03-folio-to-opac.t
+++ b/t/03-folio-to-opac.t
@@ -31,7 +31,7 @@ my $dummyMarc = makeDummyMarc();
 for (my $i = 1; $i <= 2; $i++) {
     my $expected = readFile("t/data/records/expectedOutput$i.xml");
     my $folioJson = readFile("t/data/records/input$i.json");
-    my $folioHoldings = decode_json(qq[{ "holdingsRecords2": [ $folioJson ] }]);
+    my $folioHoldings = decode_json(qq[{ "holdingsRecords2": $folioJson }]);
     my $rec = new DummyRecord($folioHoldings, $dummyMarc);
     my $holdingsXml = Net::Z3950::FOLIO::OPACXMLRecord::makeOPACXMLRecord($rec, $dummyMarc);
     is($holdingsXml, $expected, "generated holdings $i match expected XML");

--- a/t/03-folio-to-opac.t
+++ b/t/03-folio-to-opac.t
@@ -20,7 +20,7 @@ use warnings;
 use IO::File;
 use MARC::Record;
 use Cpanel::JSON::XS qw(decode_json);
-use Test::More tests => 3;
+use Test::More tests => 4;
 BEGIN { use_ok('Net::Z3950::FOLIO') };
 use Net::Z3950::FOLIO::OPACXMLRecord;
 use DummyRecord;
@@ -28,7 +28,7 @@ use DummyRecord;
 # Values taken from some random USMARC record
 my $dummyMarc = makeDummyMarc();
 
-for (my $i = 1; $i <= 2; $i++) {
+for (my $i = 1; $i <= 3; $i++) {
     my $expected = readFile("t/data/records/expectedOutput$i.xml");
     my $folioJson = readFile("t/data/records/input$i.json");
     my $folioHoldings = decode_json(qq[{ "holdingsRecords2": $folioJson }]);

--- a/t/06-marc-holdings.t
+++ b/t/06-marc-holdings.t
@@ -19,7 +19,7 @@ for (my $i = 1; $i <= 1; $i++) {
 	my $dummyMarc = makeDummyMarc();
 	my $expected = readFile("t/data/records/expectedMarc$i" . ($j == 2 ? 'byItem' : '') . ".marc");
 	my $folioJson = readFile("t/data/records/input$i.json");
-	my $folioHoldings = decode_json(qq[{ "holdingsRecords2": [ $folioJson ] }]);
+	my $folioHoldings = decode_json(qq[{ "holdingsRecords2": $folioJson }]);
 	my $rec = new DummyRecord($folioHoldings, $dummyMarc);
 	insertMARCHoldings($rec, $dummyMarc, $cfg);
 	my $marcString = $dummyMarc->as_formatted() . "\n";

--- a/t/data/records/expectedOutput3.xml
+++ b/t/data/records/expectedOutput3.xml
@@ -1,0 +1,77 @@
+<opacRecord>
+  <bibliographicRecord>
+    <record
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"
+        xmlns="http://www.loc.gov/MARC21/slim">
+    
+      <leader>03101cam a2200505Ii 4500</leader>
+      <controlfield tag="007">cr cnu---unuuu</controlfield>
+      <controlfield tag="008">1234567890123456789012345678901</controlfield>
+      <datafield tag="845" ind1=" " ind2=" ">
+        <subfield code="3">Bituminous Coal Division and National Bituminous Coal Commission Records</subfield>
+        <subfield code="a">"No information obtained from a producer disclosing cost of production or sales realization shall be made public without the consent of the producer from whom the same shall have been obtained";</subfield>
+        <subfield code="c">50 Stat.88.</subfield>
+      </datafield>
+    </record>
+  </bibliographicRecord>
+  <holdings>
+    <holding>
+      <typeOfRecord>c</typeOfRecord>
+      <encodingLevel>5</encodingLevel>
+      <format>cr</format>
+      <receiptAcqStatus>6</receiptAcqStatus>
+      <generalRetention>2</generalRetention>
+      <completeness>6</completeness>
+      <dateOfReport>678901</dateOfReport>
+      <callNumber>G1046.C3 .L56 2009eb</callNumber>
+      <shelvingData>The Amazing Adventures of Captain Gladys &quot;Stoat&quot; Pamphlet and Her Intrepid Spaniel Stig Among the Giant Pygmies of Beccles</shelvingData>
+      <copyNumber>3</copyNumber>
+      <publicNote>All Cretans are liars</publicNote>
+      <termsUseRepro>$3Bituminous Coal Division and National Bituminous Coal Commission Records$a&quot;No information obtained from a producer disclosing cost of production or sales realization shall be made public without the consent of the producer from whom the same shall have been obtained&quot;;$c50 Stat.88.</termsUseRepro>
+      <circulations>
+        <circulation>
+          <availableNow value="0" />
+          <restrictions>Missing</restrictions>
+          <itemId>01234567890</itemId>
+          <renewable value="" />
+          <onHold value="" />
+          <enumAndChron>42 29</enumAndChron>
+          <temporaryLocation>Online Library Resources</temporaryLocation>
+        </circulation>
+        <circulation>
+          <availableNow value="0" />
+          <itemId>9876543210</itemId>
+          <renewable value="" />
+          <onHold value="" />
+          <enumAndChron>3 March</enumAndChron>
+        </circulation>
+      </circulations>
+    </holding>
+    <holding>
+      <typeOfRecord>c</typeOfRecord>
+      <encodingLevel>5</encodingLevel>
+      <format>cr</format>
+      <receiptAcqStatus>6</receiptAcqStatus>
+      <generalRetention>2</generalRetention>
+      <completeness>6</completeness>
+      <dateOfReport>678901</dateOfReport>
+      <nucCode>Simmons University</nucCode>
+      <localLocation>Simmons University Library</localLocation>
+      <shelvingLocation>Online Library Resources</shelvingLocation>
+      <callNumber>G1046.C3&lt;L56&gt;2009eb</callNumber>
+      <reproductionNote>May be freely copied</reproductionNote>
+      <termsUseRepro>$3Bituminous Coal Division and National Bituminous Coal Commission Records$a&quot;No information obtained from a producer disclosing cost of production or sales realization shall be made public without the consent of the producer from whom the same shall have been obtained&quot;;$c50 Stat.88.</termsUseRepro>
+      <circulations>
+        <circulation>
+          <availableNow value="0" />
+          <itemId>9876543210</itemId>
+          <renewable value="" />
+          <onHold value="" />
+          <enumAndChron>3 March</enumAndChron>
+          <temporaryLocation>Online Library Resources</temporaryLocation>
+        </circulation>
+      </circulations>
+    </holding>
+  </holdings>
+</opacRecord>

--- a/t/data/records/input1.json
+++ b/t/data/records/input1.json
@@ -1,120 +1,108 @@
-{
-  "acquisitionFormat": null,
-  "acquisitionMethod": null,
-  "callNumber": "G1046.C3 .L56 2009eb",
-  "callNumberPrefix": null,
-  "callNumberSuffix": null,
-  "callNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
-  "copyNumber": 3,
-  "digitizationPolicy": null,
-  "discoverySuppress": null,
-  "electronicAccess": [
-    {
-      "linkText": null,
-      "materialsSpecification": null,
-      "publicNote": "Access E-Book",
-      "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
-      "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
-    }
-  ],
-  "formerIds": [],
-  "bareHoldingsItems": [
-    {
-      "accessionNumber": null,
-      "barcode": "01234567890",
-      "chronology": "29",
-      "copyNumber": "1",
-      "descriptionOfPieces": null,
-      "discoverySuppress": null,
-      "electronicAccess": [
-        {
-          "linkText": null,
-          "materialsSpecification": null,
-          "publicNote": "Access E-Book",
-          "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
-          "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
-        }
-      ],
-      "effectiveCallNumberComponents": {
-        "callNumber": "HD1131.S860 1989",
-        "prefix": "123",
-        "suffix": "abc",
-        "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d"
-      },
-      "enumeration": "42",
-      "formerIds": [],
-      "hrid": "item12345",
-      "id": "69746298-a428-11ea-b7fc-94e55e224816",
-      "inTransitDestinationServicePointId": null,
-      "itemDamagedStatusDate": null,
-      "itemDamagedStatusId": null,
-      "itemIdentifier": null,
-      "itemLevelCallNumber": "G1046.C3 .L56 2009eb",
-      "itemLevelCallNumberPrefix": null,
-      "itemLevelCallNumberSuffix": null,
-      "itemLevelCallNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
-      "metadata": null,
-      "missingPieces": null,
-      "missingPiecesDate": null,
-      "notes": [],
-      "numberOfMissingPieces": null,
-      "numberOfPieces": null,
-      "permanentLocationId": null,
-      "statisticalCodeIds": [],
-      "status": {
-        "name": "Missing"
-      },
-      "temporaryLoanTypeId": null,
-      "temporaryLocationId": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
-      "temporaryLocation": {
-        "campus": {
-          "code": "SIMC",
-          "id": "ad802880-d3c1-47ea-84d9-5f6574ec72a2",
-          "institutionId": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
-          "name": "Main Campus"
-        },
-        "campusId": "ad802880-d3c1-47ea-84d9-5f6574ec72a2",
-        "code": "elere",
-        "description": null,
-        "discoveryDisplayName": "Online Library Resources",
-        "id": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
-        "institution": {
-          "code": "SIM",
-          "id": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
-          "name": "Simmons University"
-        },
-        "institutionId": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
-        "isActive": true,
-        "library": {
-          "code": "SIM",
-          "id": "2805564c-b9e2-45ba-9c6f-670b11b808e2",
-          "name": "Simmons & Wentworth Library"
-        },
-        "libraryId": "2805564c-b9e2-45ba-9c6f-670b11b808e2",
-        "metadata": {
-          "createdByUserId": "7a16958e-af23-5002-8191-d7a96f5f8070",
-          "createdByUsername": null,
-          "createdDate": "2020-06-01T16:29:19.798+0000",
-          "updatedByUserId": "7a16958e-af23-5002-8191-d7a96f5f8070",
-          "updatedByUsername": null,
-          "updatedDate": "2020-06-01T16:29:19.798+0000"
-        },
-        "name": "Online Library Resources",
-        "primaryServicePoint": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
-        "primaryServicePointObject": {
-          "code": "Online",
-          "description": null,
-          "discoveryDisplayName": "Online",
-          "id": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
-          "name": "Online",
-          "pickupLocation": false,
-          "shelvingLagTime": 0
-        },
-        "servicePointIds": [
-          "7c5abc9f-f3d7-4856-b8d7-6712462ca007"
-        ],
-        "servicePoints": [
+[
+  {
+    "acquisitionFormat": null,
+    "acquisitionMethod": null,
+    "callNumber": "G1046.C3 .L56 2009eb",
+    "callNumberPrefix": null,
+    "callNumberSuffix": null,
+    "callNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+    "copyNumber": 3,
+    "digitizationPolicy": null,
+    "discoverySuppress": null,
+    "electronicAccess": [
+      {
+        "linkText": null,
+        "materialsSpecification": null,
+        "publicNote": "Access E-Book",
+        "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+        "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
+      }
+    ],
+    "formerIds": [],
+    "bareHoldingsItems": [
+      {
+        "accessionNumber": null,
+        "barcode": "01234567890",
+        "chronology": "29",
+        "copyNumber": "1",
+        "descriptionOfPieces": null,
+        "discoverySuppress": null,
+        "electronicAccess": [
           {
+            "linkText": null,
+            "materialsSpecification": null,
+            "publicNote": "Access E-Book",
+            "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+            "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
+          }
+        ],
+        "effectiveCallNumberComponents": {
+          "callNumber": "HD1131.S860 1989",
+          "prefix": "123",
+          "suffix": "abc",
+          "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d"
+        },
+        "enumeration": "42",
+        "formerIds": [],
+        "hrid": "item12345",
+        "id": "69746298-a428-11ea-b7fc-94e55e224816",
+        "inTransitDestinationServicePointId": null,
+        "itemDamagedStatusDate": null,
+        "itemDamagedStatusId": null,
+        "itemIdentifier": null,
+        "itemLevelCallNumber": "G1046.C3 .L56 2009eb",
+        "itemLevelCallNumberPrefix": null,
+        "itemLevelCallNumberSuffix": null,
+        "itemLevelCallNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "metadata": null,
+        "missingPieces": null,
+        "missingPiecesDate": null,
+        "notes": [],
+        "numberOfMissingPieces": null,
+        "numberOfPieces": null,
+        "permanentLocationId": null,
+        "statisticalCodeIds": [],
+        "status": {
+          "name": "Missing"
+        },
+        "temporaryLoanTypeId": null,
+        "temporaryLocationId": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
+        "temporaryLocation": {
+          "campus": {
+            "code": "SIMC",
+            "id": "ad802880-d3c1-47ea-84d9-5f6574ec72a2",
+            "institutionId": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
+            "name": "Main Campus"
+          },
+          "campusId": "ad802880-d3c1-47ea-84d9-5f6574ec72a2",
+          "code": "elere",
+          "description": null,
+          "discoveryDisplayName": "Online Library Resources",
+          "id": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
+          "institution": {
+            "code": "SIM",
+            "id": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
+            "name": "Simmons University"
+          },
+          "institutionId": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
+          "isActive": true,
+          "library": {
+            "code": "SIM",
+            "id": "2805564c-b9e2-45ba-9c6f-670b11b808e2",
+            "name": "Simmons & Wentworth Library"
+          },
+          "libraryId": "2805564c-b9e2-45ba-9c6f-670b11b808e2",
+          "metadata": {
+            "createdByUserId": "7a16958e-af23-5002-8191-d7a96f5f8070",
+            "createdByUsername": null,
+            "createdDate": "2020-06-01T16:29:19.798+0000",
+            "updatedByUserId": "7a16958e-af23-5002-8191-d7a96f5f8070",
+            "updatedByUsername": null,
+            "updatedDate": "2020-06-01T16:29:19.798+0000"
+          },
+          "name": "Online Library Resources",
+          "primaryServicePoint": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
+          "primaryServicePointObject": {
             "code": "Online",
             "description": null,
             "discoveryDisplayName": "Online",
@@ -122,96 +110,110 @@
             "name": "Online",
             "pickupLocation": false,
             "shelvingLagTime": 0
-          }
-        ]
-      },
-      "volume": "1",
-      "yearCaption": ["a", "b"]
-    },
-    {
-      "accessionNumber": null,
-      "barcode": "9876543210",
-      "chronology": "March",
-      "copyNumber": "1",
-      "descriptionOfPieces": null,
-      "discoverySuppress": true,
-      "electronicAccess": [
-        {
-          "linkText": null,
-          "materialsSpecification": null,
-          "publicNote": "Access E-Book",
-          "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
-          "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
-        }
-      ],
-      "enumeration": "3",
-      "formerIds": [],
-      "hrid": "i2036897",
-      "id": "69746298-a428-11ea-b7fc-94e55e224816",
-      "inTransitDestinationServicePointId": null,
-      "itemDamagedStatusDate": null,
-      "itemDamagedStatusId": null,
-      "itemIdentifier": null,
-      "itemLevelCallNumber": "G1046.C3 .L56 2009eb",
-      "itemLevelCallNumberPrefix": null,
-      "itemLevelCallNumberSuffix": null,
-      "itemLevelCallNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
-      "metadata": null,
-      "missingPieces": null,
-      "missingPiecesDate": null,
-      "notes": [
-        {
-          "itemNoteType": {
-            "id": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
-            "name": "Note",
-            "source": "folio"
           },
-          "itemNoteTypeId": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
-          "note": "Online",
-          "staffOnly": false
-        }
-      ],
-      "numberOfMissingPieces": null,
-      "numberOfPieces": null,
-      "permanentLocationId": null,
-      "statisticalCodeIds": [],
-      "status": {
-        "name": "Available"
+          "servicePointIds": [
+            "7c5abc9f-f3d7-4856-b8d7-6712462ca007"
+          ],
+          "servicePoints": [
+            {
+              "code": "Online",
+              "description": null,
+              "discoveryDisplayName": "Online",
+              "id": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
+              "name": "Online",
+              "pickupLocation": false,
+              "shelvingLagTime": 0
+            }
+          ]
+        },
+        "volume": "1",
+        "yearCaption": ["a", "b"]
       },
-      "temporaryLoanTypeId": null,
-      "temporaryLocationId": null,
-      "volume": "",
-      "yearCaption": []
-    }
-  ],
-  "holdingsStatements": [],
-  "holdingsStatementsForIndexes": [],
-  "holdingsStatementsForSupplements": [],
-  "holdingsTypeId": null,
-  "hrid": "b2245518-elere",
-  "id": "697448a8-a428-11ea-b7fc-94e55e224816",
-  "illPolicyId": null,
-  "instanceId": "2ff48cb6-a41c-11ea-8d99-9ee25e224816",
-  "metadata": null,
-  "notes": [
-    {
-      "holdingsNoteType": {
-        "id": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
-        "name": "Public",
-        "source": "folio"
-      },
-      "holdingsNoteTypeId": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
-      "note": "All Cretans are liars",
-      "staffOnly": false
-    }
-  ],
-  "numberOfItems": null,
-  "permanentLocation": null,
-  "permanentLocationId": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
-  "receiptStatus": null,
-  "receivingHistory": null,
-  "retentionPolicy": null,
-  "shelvingTitle": "The Amazing Adventures of Captain Gladys \"Stoat\" Pamphlet and Her Intrepid Spaniel Stig Among the Giant Pygmies of Beccles",
-  "statisticalCodeIds": [],
-  "temporaryLocationId": null
-}
+      {
+        "accessionNumber": null,
+        "barcode": "9876543210",
+        "chronology": "March",
+        "copyNumber": "1",
+        "descriptionOfPieces": null,
+        "discoverySuppress": true,
+        "electronicAccess": [
+          {
+            "linkText": null,
+            "materialsSpecification": null,
+            "publicNote": "Access E-Book",
+            "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+            "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
+          }
+        ],
+        "enumeration": "3",
+        "formerIds": [],
+        "hrid": "i2036897",
+        "id": "69746298-a428-11ea-b7fc-94e55e224816",
+        "inTransitDestinationServicePointId": null,
+        "itemDamagedStatusDate": null,
+        "itemDamagedStatusId": null,
+        "itemIdentifier": null,
+        "itemLevelCallNumber": "G1046.C3 .L56 2009eb",
+        "itemLevelCallNumberPrefix": null,
+        "itemLevelCallNumberSuffix": null,
+        "itemLevelCallNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "metadata": null,
+        "missingPieces": null,
+        "missingPiecesDate": null,
+        "notes": [
+          {
+            "itemNoteType": {
+              "id": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+              "name": "Note",
+              "source": "folio"
+            },
+            "itemNoteTypeId": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+            "note": "Online",
+            "staffOnly": false
+          }
+        ],
+        "numberOfMissingPieces": null,
+        "numberOfPieces": null,
+        "permanentLocationId": null,
+        "statisticalCodeIds": [],
+        "status": {
+          "name": "Available"
+        },
+        "temporaryLoanTypeId": null,
+        "temporaryLocationId": null,
+        "volume": "",
+        "yearCaption": []
+      }
+    ],
+    "holdingsStatements": [],
+    "holdingsStatementsForIndexes": [],
+    "holdingsStatementsForSupplements": [],
+    "holdingsTypeId": null,
+    "hrid": "b2245518-elere",
+    "id": "697448a8-a428-11ea-b7fc-94e55e224816",
+    "illPolicyId": null,
+    "instanceId": "2ff48cb6-a41c-11ea-8d99-9ee25e224816",
+    "metadata": null,
+    "notes": [
+      {
+        "holdingsNoteType": {
+          "id": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+          "name": "Public",
+          "source": "folio"
+        },
+        "holdingsNoteTypeId": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+        "note": "All Cretans are liars",
+        "staffOnly": false
+      }
+    ],
+    "numberOfItems": null,
+    "permanentLocation": null,
+    "permanentLocationId": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
+    "receiptStatus": null,
+    "receivingHistory": null,
+    "retentionPolicy": null,
+    "shelvingTitle": "The Amazing Adventures of Captain Gladys \"Stoat\" Pamphlet and Her Intrepid Spaniel Stig Among the Giant Pygmies of Beccles",
+    "statisticalCodeIds": [],
+    "temporaryLocationId": null
+  }
+]

--- a/t/data/records/input2.json
+++ b/t/data/records/input2.json
@@ -1,161 +1,149 @@
-{
-  "acquisitionFormat": null,
-  "acquisitionMethod": null,
-  "callNumber": "G1046.C3<L56>2009eb",
-  "callNumberPrefix": null,
-  "callNumberSuffix": null,
-  "callNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
-  "copyNumber": null,
-  "digitizationPolicy": null,
-  "discoverySuppress": null,
-  "electronicAccess": [
-    {
-      "linkText": null,
-      "materialsSpecification": null,
-      "publicNote": "Access E-Book",
-      "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
-      "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
-    }
-  ],
-  "formerIds": [],
-  "bareHoldingsItems": [
-    {
-      "accessionNumber": null,
-      "barcode": "9876543210",
-      "chronology": "March",
-      "copyNumber": "1",
-      "descriptionOfPieces": null,
-      "discoverySuppress": true,
-      "electronicAccess": [
-        {
-          "linkText": null,
-          "materialsSpecification": null,
-          "publicNote": "Access E-Book",
-          "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
-          "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
-        }
-      ],
-      "enumeration": "3",
-      "formerIds": [],
-      "hrid": "i2036897",
-      "id": "69746298-a428-11ea-b7fc-94e55e224816",
-      "inTransitDestinationServicePointId": null,
-      "itemDamagedStatusDate": null,
-      "itemDamagedStatusId": null,
-      "itemIdentifier": null,
-      "itemLevelCallNumber": "G1046.C3 .L56 2009eb",
-      "itemLevelCallNumberPrefix": null,
-      "itemLevelCallNumberSuffix": null,
-      "itemLevelCallNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
-      "metadata": null,
-      "missingPieces": null,
-      "missingPiecesDate": null,
-      "notes": [
-        {
-          "itemNoteType": {
-            "id": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
-            "name": "Note",
-            "source": "folio"
-          },
-          "itemNoteTypeId": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
-          "note": "Online",
-          "staffOnly": false
-        }
-      ],
-      "numberOfMissingPieces": null,
-      "numberOfPieces": null,
-      "permanentLocationId": null,
-      "statisticalCodeIds": [],
-      "status": {
-        "name": "Available"
-      },
-      "temporaryLoanTypeId": null,
-      "temporaryLocationId": null,
-      "volume": "",
-      "yearCaption": []
-    }
-  ],
-  "holdingsStatements": [],
-  "holdingsStatementsForIndexes": [],
-  "holdingsStatementsForSupplements": [],
-  "holdingsTypeId": null,
-  "hrid": "b2245518-elere",
-  "id": "697448a8-a428-11ea-b7fc-94e55e224816",
-  "illPolicyId": null,
-  "instanceId": "2ff48cb6-a41c-11ea-8d99-9ee25e224816",
-  "metadata": null,
-  "notes": [
-    {
-      "holdingsNoteType": {
-        "id": "a336ce03-f68a-4875-b82a-4f21df8139c5",
-        "name": "Bound with",
-        "source": "local"
-      },
-      "holdingsNoteTypeId": "a336ce03-f68a-4875-b82a-4f21df8139c5",
-      "note": "This is a holdings note",
-      "staffOnly": false
-    },
-    {
-      "holdingsNoteType": {
-        "id": "6a41b714-8574-4084-8d64-a9373c3fbb59",
-        "name": "Reproduction",
-        "source": "folio"
-      },
-      "holdingsNoteTypeId": "6a41b714-8574-4084-8d64-a9373c3fbb59",
-      "note": "May be freely copied",
-      "staffOnly": false
-    }
-  ],
-  "numberOfItems": null,
-  "permanentLocation": {
-    "campus": {
-      "code": "SIMC",
-      "id": "ad802880-d3c1-47ea-84d9-5f6574ec72a2",
-      "institutionId": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
-      "name": "Main Campus"
-    },
-    "campusId": "ad802880-d3c1-47ea-84d9-5f6574ec72a2",
-    "code": "elere",
-    "description": null,
-    "discoveryDisplayName": "Online Library Resources",
-    "id": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
-    "institution": {
-      "code": "SIM",
-      "id": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
-      "name": "Simmons University"
-    },
-    "institutionId": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
-    "isActive": true,
-    "library": {
-      "code": "SIM",
-      "id": "2805564c-b9e2-45ba-9c6f-670b11b808e2",
-      "name": "Simmons University Library"
-    },
-    "libraryId": "2805564c-b9e2-45ba-9c6f-670b11b808e2",
-    "metadata": {
-      "createdByUserId": "7a16958e-af23-5002-8191-d7a96f5f8070",
-      "createdByUsername": null,
-      "createdDate": "2020-06-01T16:29:19.798+0000",
-      "updatedByUserId": "7a16958e-af23-5002-8191-d7a96f5f8070",
-      "updatedByUsername": null,
-      "updatedDate": "2020-06-01T16:29:19.798+0000"
-    },
-    "name": "Online Library Resources",
-    "primaryServicePoint": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
-    "primaryServicePointObject": {
-      "code": "Online",
-      "description": null,
-      "discoveryDisplayName": "Online",
-      "id": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
-      "name": "Online",
-      "pickupLocation": false,
-      "shelvingLagTime": 0
-    },
-    "servicePointIds": [
-      "7c5abc9f-f3d7-4856-b8d7-6712462ca007"
-    ],
-    "servicePoints": [
+[
+  {
+    "acquisitionFormat": null,
+    "acquisitionMethod": null,
+    "callNumber": "G1046.C3<L56>2009eb",
+    "callNumberPrefix": null,
+    "callNumberSuffix": null,
+    "callNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+    "copyNumber": null,
+    "digitizationPolicy": null,
+    "discoverySuppress": null,
+    "electronicAccess": [
       {
+        "linkText": null,
+        "materialsSpecification": null,
+        "publicNote": "Access E-Book",
+        "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+        "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
+      }
+    ],
+    "formerIds": [],
+    "bareHoldingsItems": [
+      {
+        "accessionNumber": null,
+        "barcode": "9876543210",
+        "chronology": "March",
+        "copyNumber": "1",
+        "descriptionOfPieces": null,
+        "discoverySuppress": true,
+        "electronicAccess": [
+          {
+            "linkText": null,
+            "materialsSpecification": null,
+            "publicNote": "Access E-Book",
+            "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+            "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
+          }
+        ],
+        "enumeration": "3",
+        "formerIds": [],
+        "hrid": "i2036897",
+        "id": "69746298-a428-11ea-b7fc-94e55e224816",
+        "inTransitDestinationServicePointId": null,
+        "itemDamagedStatusDate": null,
+        "itemDamagedStatusId": null,
+        "itemIdentifier": null,
+        "itemLevelCallNumber": "G1046.C3 .L56 2009eb",
+        "itemLevelCallNumberPrefix": null,
+        "itemLevelCallNumberSuffix": null,
+        "itemLevelCallNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "metadata": null,
+        "missingPieces": null,
+        "missingPiecesDate": null,
+        "notes": [
+          {
+            "itemNoteType": {
+              "id": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+              "name": "Note",
+              "source": "folio"
+            },
+            "itemNoteTypeId": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+            "note": "Online",
+            "staffOnly": false
+          }
+        ],
+        "numberOfMissingPieces": null,
+        "numberOfPieces": null,
+        "permanentLocationId": null,
+        "statisticalCodeIds": [],
+        "status": {
+          "name": "Available"
+        },
+        "temporaryLoanTypeId": null,
+        "temporaryLocationId": null,
+        "volume": "",
+        "yearCaption": []
+      }
+    ],
+    "holdingsStatements": [],
+    "holdingsStatementsForIndexes": [],
+    "holdingsStatementsForSupplements": [],
+    "holdingsTypeId": null,
+    "hrid": "b2245518-elere",
+    "id": "697448a8-a428-11ea-b7fc-94e55e224816",
+    "illPolicyId": null,
+    "instanceId": "2ff48cb6-a41c-11ea-8d99-9ee25e224816",
+    "metadata": null,
+    "notes": [
+      {
+        "holdingsNoteType": {
+          "id": "a336ce03-f68a-4875-b82a-4f21df8139c5",
+          "name": "Bound with",
+          "source": "local"
+        },
+        "holdingsNoteTypeId": "a336ce03-f68a-4875-b82a-4f21df8139c5",
+        "note": "This is a holdings note",
+        "staffOnly": false
+      },
+      {
+        "holdingsNoteType": {
+          "id": "6a41b714-8574-4084-8d64-a9373c3fbb59",
+          "name": "Reproduction",
+          "source": "folio"
+        },
+        "holdingsNoteTypeId": "6a41b714-8574-4084-8d64-a9373c3fbb59",
+        "note": "May be freely copied",
+        "staffOnly": false
+      }
+    ],
+    "numberOfItems": null,
+    "permanentLocation": {
+      "campus": {
+        "code": "SIMC",
+        "id": "ad802880-d3c1-47ea-84d9-5f6574ec72a2",
+        "institutionId": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
+        "name": "Main Campus"
+      },
+      "campusId": "ad802880-d3c1-47ea-84d9-5f6574ec72a2",
+      "code": "elere",
+      "description": null,
+      "discoveryDisplayName": "Online Library Resources",
+      "id": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
+      "institution": {
+        "code": "SIM",
+        "id": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
+        "name": "Simmons University"
+      },
+      "institutionId": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
+      "isActive": true,
+      "library": {
+        "code": "SIM",
+        "id": "2805564c-b9e2-45ba-9c6f-670b11b808e2",
+        "name": "Simmons University Library"
+      },
+      "libraryId": "2805564c-b9e2-45ba-9c6f-670b11b808e2",
+      "metadata": {
+        "createdByUserId": "7a16958e-af23-5002-8191-d7a96f5f8070",
+        "createdByUsername": null,
+        "createdDate": "2020-06-01T16:29:19.798+0000",
+        "updatedByUserId": "7a16958e-af23-5002-8191-d7a96f5f8070",
+        "updatedByUsername": null,
+        "updatedDate": "2020-06-01T16:29:19.798+0000"
+      },
+      "name": "Online Library Resources",
+      "primaryServicePoint": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
+      "primaryServicePointObject": {
         "code": "Online",
         "description": null,
         "discoveryDisplayName": "Online",
@@ -163,14 +151,28 @@
         "name": "Online",
         "pickupLocation": false,
         "shelvingLagTime": 0
-      }
-    ]
-  },
-  "permanentLocationId": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
-  "receiptStatus": null,
-  "receivingHistory": null,
-  "retentionPolicy": null,
-  "shelvingTitle": null,
-  "statisticalCodeIds": [],
-  "temporaryLocationId": null
-}
+      },
+      "servicePointIds": [
+        "7c5abc9f-f3d7-4856-b8d7-6712462ca007"
+      ],
+      "servicePoints": [
+        {
+          "code": "Online",
+          "description": null,
+          "discoveryDisplayName": "Online",
+          "id": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
+          "name": "Online",
+          "pickupLocation": false,
+          "shelvingLagTime": 0
+        }
+      ]
+    },
+    "permanentLocationId": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
+    "receiptStatus": null,
+    "receivingHistory": null,
+    "retentionPolicy": null,
+    "shelvingTitle": null,
+    "statisticalCodeIds": [],
+    "temporaryLocationId": null
+  }
+]

--- a/t/data/records/input3.json
+++ b/t/data/records/input3.json
@@ -1,0 +1,395 @@
+[
+  {
+    "acquisitionFormat": null,
+    "acquisitionMethod": null,
+    "callNumber": "G1046.C3 .L56 2009eb",
+    "callNumberPrefix": null,
+    "callNumberSuffix": null,
+    "callNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+    "copyNumber": 3,
+    "digitizationPolicy": null,
+    "discoverySuppress": null,
+    "electronicAccess": [
+      {
+        "linkText": null,
+        "materialsSpecification": null,
+        "publicNote": "Access E-Book",
+        "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+        "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
+      }
+    ],
+    "formerIds": [],
+    "bareHoldingsItems": [
+      {
+        "accessionNumber": null,
+        "barcode": "01234567890",
+        "chronology": "29",
+        "copyNumber": "1",
+        "descriptionOfPieces": null,
+        "discoverySuppress": null,
+        "electronicAccess": [
+          {
+            "linkText": null,
+            "materialsSpecification": null,
+            "publicNote": "Access E-Book",
+            "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+            "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
+          }
+        ],
+        "effectiveCallNumberComponents": {
+          "callNumber": "HD1131.S860 1989",
+          "prefix": "123",
+          "suffix": "abc",
+          "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d"
+        },
+        "enumeration": "42",
+        "formerIds": [],
+        "hrid": "item12345",
+        "id": "69746298-a428-11ea-b7fc-94e55e224816",
+        "inTransitDestinationServicePointId": null,
+        "itemDamagedStatusDate": null,
+        "itemDamagedStatusId": null,
+        "itemIdentifier": null,
+        "itemLevelCallNumber": "G1046.C3 .L56 2009eb",
+        "itemLevelCallNumberPrefix": null,
+        "itemLevelCallNumberSuffix": null,
+        "itemLevelCallNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "metadata": null,
+        "missingPieces": null,
+        "missingPiecesDate": null,
+        "notes": [],
+        "numberOfMissingPieces": null,
+        "numberOfPieces": null,
+        "permanentLocationId": null,
+        "statisticalCodeIds": [],
+        "status": {
+          "name": "Missing"
+        },
+        "temporaryLoanTypeId": null,
+        "temporaryLocationId": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
+        "temporaryLocation": {
+          "campus": {
+            "code": "SIMC",
+            "id": "ad802880-d3c1-47ea-84d9-5f6574ec72a2",
+            "institutionId": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
+            "name": "Main Campus"
+          },
+          "campusId": "ad802880-d3c1-47ea-84d9-5f6574ec72a2",
+          "code": "elere",
+          "description": null,
+          "discoveryDisplayName": "Online Library Resources",
+          "id": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
+          "institution": {
+            "code": "SIM",
+            "id": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
+            "name": "Simmons University"
+          },
+          "institutionId": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
+          "isActive": true,
+          "library": {
+            "code": "SIM",
+            "id": "2805564c-b9e2-45ba-9c6f-670b11b808e2",
+            "name": "Simmons & Wentworth Library"
+          },
+          "libraryId": "2805564c-b9e2-45ba-9c6f-670b11b808e2",
+          "metadata": {
+            "createdByUserId": "7a16958e-af23-5002-8191-d7a96f5f8070",
+            "createdByUsername": null,
+            "createdDate": "2020-06-01T16:29:19.798+0000",
+            "updatedByUserId": "7a16958e-af23-5002-8191-d7a96f5f8070",
+            "updatedByUsername": null,
+            "updatedDate": "2020-06-01T16:29:19.798+0000"
+          },
+          "name": "Online Library Resources",
+          "primaryServicePoint": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
+          "primaryServicePointObject": {
+            "code": "Online",
+            "description": null,
+            "discoveryDisplayName": "Online",
+            "id": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
+            "name": "Online",
+            "pickupLocation": false,
+            "shelvingLagTime": 0
+          },
+          "servicePointIds": [
+            "7c5abc9f-f3d7-4856-b8d7-6712462ca007"
+          ],
+          "servicePoints": [
+            {
+              "code": "Online",
+              "description": null,
+              "discoveryDisplayName": "Online",
+              "id": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
+              "name": "Online",
+              "pickupLocation": false,
+              "shelvingLagTime": 0
+            }
+          ]
+        },
+        "volume": "1",
+        "yearCaption": ["a", "b"]
+      },
+      {
+        "accessionNumber": null,
+        "barcode": "9876543210",
+        "chronology": "March",
+        "copyNumber": "1",
+        "descriptionOfPieces": null,
+        "discoverySuppress": true,
+        "electronicAccess": [
+          {
+            "linkText": null,
+            "materialsSpecification": null,
+            "publicNote": "Access E-Book",
+            "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+            "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
+          }
+        ],
+        "enumeration": "3",
+        "formerIds": [],
+        "hrid": "i2036897",
+        "id": "69746298-a428-11ea-b7fc-94e55e224816",
+        "inTransitDestinationServicePointId": null,
+        "itemDamagedStatusDate": null,
+        "itemDamagedStatusId": null,
+        "itemIdentifier": null,
+        "itemLevelCallNumber": "G1046.C3 .L56 2009eb",
+        "itemLevelCallNumberPrefix": null,
+        "itemLevelCallNumberSuffix": null,
+        "itemLevelCallNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "metadata": null,
+        "missingPieces": null,
+        "missingPiecesDate": null,
+        "notes": [
+          {
+            "itemNoteType": {
+              "id": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+              "name": "Note",
+              "source": "folio"
+            },
+            "itemNoteTypeId": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+            "note": "Online",
+            "staffOnly": false
+          }
+        ],
+        "numberOfMissingPieces": null,
+        "numberOfPieces": null,
+        "permanentLocationId": null,
+        "statisticalCodeIds": [],
+        "status": {
+          "name": "Available"
+        },
+        "temporaryLoanTypeId": null,
+        "temporaryLocationId": null,
+        "volume": "",
+        "yearCaption": []
+      }
+    ],
+    "holdingsStatements": [],
+    "holdingsStatementsForIndexes": [],
+    "holdingsStatementsForSupplements": [],
+    "holdingsTypeId": null,
+    "hrid": "b2245518-elere",
+    "id": "697448a8-a428-11ea-b7fc-94e55e224816",
+    "illPolicyId": null,
+    "instanceId": "2ff48cb6-a41c-11ea-8d99-9ee25e224816",
+    "metadata": null,
+    "notes": [
+      {
+        "holdingsNoteType": {
+          "id": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+          "name": "Public",
+          "source": "folio"
+        },
+        "holdingsNoteTypeId": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+        "note": "All Cretans are liars",
+        "staffOnly": false
+      }
+    ],
+    "numberOfItems": null,
+    "permanentLocation": null,
+    "permanentLocationId": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
+    "receiptStatus": null,
+    "receivingHistory": null,
+    "retentionPolicy": null,
+    "shelvingTitle": "The Amazing Adventures of Captain Gladys \"Stoat\" Pamphlet and Her Intrepid Spaniel Stig Among the Giant Pygmies of Beccles",
+    "statisticalCodeIds": [],
+    "temporaryLocationId": null
+  },
+  {
+    "acquisitionFormat": null,
+    "acquisitionMethod": null,
+    "callNumber": "G1046.C3<L56>2009eb",
+    "callNumberPrefix": null,
+    "callNumberSuffix": null,
+    "callNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+    "copyNumber": null,
+    "digitizationPolicy": null,
+    "discoverySuppress": null,
+    "electronicAccess": [
+      {
+        "linkText": null,
+        "materialsSpecification": null,
+        "publicNote": "Access E-Book",
+        "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+        "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
+      }
+    ],
+    "formerIds": [],
+    "bareHoldingsItems": [
+      {
+        "accessionNumber": null,
+        "barcode": "9876543210",
+        "chronology": "March",
+        "copyNumber": "1",
+        "descriptionOfPieces": null,
+        "discoverySuppress": true,
+        "electronicAccess": [
+          {
+            "linkText": null,
+            "materialsSpecification": null,
+            "publicNote": "Access E-Book",
+            "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+            "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
+          }
+        ],
+        "enumeration": "3",
+        "formerIds": [],
+        "hrid": "i2036897",
+        "id": "69746298-a428-11ea-b7fc-94e55e224816",
+        "inTransitDestinationServicePointId": null,
+        "itemDamagedStatusDate": null,
+        "itemDamagedStatusId": null,
+        "itemIdentifier": null,
+        "itemLevelCallNumber": "G1046.C3 .L56 2009eb",
+        "itemLevelCallNumberPrefix": null,
+        "itemLevelCallNumberSuffix": null,
+        "itemLevelCallNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "metadata": null,
+        "missingPieces": null,
+        "missingPiecesDate": null,
+        "notes": [
+          {
+            "itemNoteType": {
+              "id": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+              "name": "Note",
+              "source": "folio"
+            },
+            "itemNoteTypeId": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+            "note": "Online",
+            "staffOnly": false
+          }
+        ],
+        "numberOfMissingPieces": null,
+        "numberOfPieces": null,
+        "permanentLocationId": null,
+        "statisticalCodeIds": [],
+        "status": {
+          "name": "Available"
+        },
+        "temporaryLoanTypeId": null,
+        "temporaryLocationId": null,
+        "volume": "",
+        "yearCaption": []
+      }
+    ],
+    "holdingsStatements": [],
+    "holdingsStatementsForIndexes": [],
+    "holdingsStatementsForSupplements": [],
+    "holdingsTypeId": null,
+    "hrid": "b2245518-elere",
+    "id": "697448a8-a428-11ea-b7fc-94e55e224816",
+    "illPolicyId": null,
+    "instanceId": "2ff48cb6-a41c-11ea-8d99-9ee25e224816",
+    "metadata": null,
+    "notes": [
+      {
+        "holdingsNoteType": {
+          "id": "a336ce03-f68a-4875-b82a-4f21df8139c5",
+          "name": "Bound with",
+          "source": "local"
+        },
+        "holdingsNoteTypeId": "a336ce03-f68a-4875-b82a-4f21df8139c5",
+        "note": "This is a holdings note",
+        "staffOnly": false
+      },
+      {
+        "holdingsNoteType": {
+          "id": "6a41b714-8574-4084-8d64-a9373c3fbb59",
+          "name": "Reproduction",
+          "source": "folio"
+        },
+        "holdingsNoteTypeId": "6a41b714-8574-4084-8d64-a9373c3fbb59",
+        "note": "May be freely copied",
+        "staffOnly": false
+      }
+    ],
+    "numberOfItems": null,
+    "permanentLocation": {
+      "campus": {
+        "code": "SIMC",
+        "id": "ad802880-d3c1-47ea-84d9-5f6574ec72a2",
+        "institutionId": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
+        "name": "Main Campus"
+      },
+      "campusId": "ad802880-d3c1-47ea-84d9-5f6574ec72a2",
+      "code": "elere",
+      "description": null,
+      "discoveryDisplayName": "Online Library Resources",
+      "id": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
+      "institution": {
+        "code": "SIM",
+        "id": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
+        "name": "Simmons University"
+      },
+      "institutionId": "abc7866d-e53f-4da1-bcc0-84535a9a832e",
+      "isActive": true,
+      "library": {
+        "code": "SIM",
+        "id": "2805564c-b9e2-45ba-9c6f-670b11b808e2",
+        "name": "Simmons University Library"
+      },
+      "libraryId": "2805564c-b9e2-45ba-9c6f-670b11b808e2",
+      "metadata": {
+        "createdByUserId": "7a16958e-af23-5002-8191-d7a96f5f8070",
+        "createdByUsername": null,
+        "createdDate": "2020-06-01T16:29:19.798+0000",
+        "updatedByUserId": "7a16958e-af23-5002-8191-d7a96f5f8070",
+        "updatedByUsername": null,
+        "updatedDate": "2020-06-01T16:29:19.798+0000"
+      },
+      "name": "Online Library Resources",
+      "primaryServicePoint": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
+      "primaryServicePointObject": {
+        "code": "Online",
+        "description": null,
+        "discoveryDisplayName": "Online",
+        "id": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
+        "name": "Online",
+        "pickupLocation": false,
+        "shelvingLagTime": 0
+      },
+      "servicePointIds": [
+        "7c5abc9f-f3d7-4856-b8d7-6712462ca007"
+      ],
+      "servicePoints": [
+        {
+          "code": "Online",
+          "description": null,
+          "discoveryDisplayName": "Online",
+          "id": "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
+          "name": "Online",
+          "pickupLocation": false,
+          "shelvingLagTime": 0
+        }
+      ]
+    },
+    "permanentLocationId": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
+    "receiptStatus": null,
+    "receivingHistory": null,
+    "retentionPolicy": null,
+    "shelvingTitle": null,
+    "statisticalCodeIds": [],
+    "temporaryLocationId": null
+  }
+]


### PR DESCRIPTION
Fixes ZF-78.