### PR TITLE
"0" values are now included in MARC subfields

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Revision history for Perl extension Net::Z3950::FOLIO.
 
+## 3.3.3 (IN PROGRESS)
+
+* MARC-holdings subfield values of "0" are now included in the record, unlike other falsy values. Allows `availableNow=0` and fixes ZF-80.
+
 ## [3.2.0](https://github.com/folio-org/Net-Z3950-FOLIO/tree/v3.2.0) (Fri Jan 13 19:13:17 GMT 2023)
 
 * Loosen requirements for `search` interface to allow v0.7. Fixes ZF-71.

--- a/MANIFEST
+++ b/MANIFEST
@@ -26,6 +26,7 @@ doc/release-procedure.md
 doc/source-code-overview.md
 doc/srs/using-srs.md
 etc/config.able.json
+etc/config.bugfest_nolana.json
 etc/config.chicago.json
 etc/config.dummy.json
 etc/config.fieldPerItem.json

--- a/etc/config.bugfest_nolana.json
+++ b/etc/config.bugfest_nolana.json
@@ -1,0 +1,23 @@
+{
+  "okapi": {
+    "url": "https://okapi-bugfest-nolana.int.aws.folio.org",
+    "tenant": "fs09000000"
+  },
+  "login": {
+    "username": "${OKAPI_USER-folio}",
+    "password": "${OKAPI_BUGFEST_NOLANA_PASSWORD}"
+  },
+  "marcHoldings": {
+    "fieldPerItem": true,
+    "field": "852",
+    "indicators": [" "," "],
+    "holdingsElements": {
+    },
+    "itemElements": {
+      "d": "_permanentLocation",
+      "b": "itemId",
+      "k": "_callNumberPrefix",
+      "r": "availableNow"
+    }
+  }
+}

--- a/lib/Net/Z3950/FOLIO/MARCHoldings.pm
+++ b/lib/Net/Z3950/FOLIO/MARCHoldings.pm
@@ -60,7 +60,7 @@ sub _addSubfields {
 	my $name = $elementsCfg->{$subfield};
 	my $val = $data->{$name};
 	# warn "considering key '$subfield' mapped to '$name' with value '$val'";
-	if ($val) {
+	if ($val || (defined $val && "$val" eq '0')) {
 	    $marcField = _addSubfield($marcField, $marcCfg, $subfield, $val);
 	}
     }


### PR DESCRIPTION
MARC-holdings subfield values of "0" are now included in the record, unlike other falsy values.

Allows `availableNow=0`.

Fixes ZF-80.