### PR TITLE
OPAC-XML postprocessing for 2nd/later circulations

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Revision history for Perl extension Net::Z3950::FOLIO.
 
+## 3.3.3 (IN PROGRESS)
+
+* Post-processing is applied to all circulations within an OPAC XML holdings record, not just the first. Fixes ZF-86.
+
 ## [3.3.2](https://github.com/folio-org/Net-Z3950-FOLIO/tree/v3.3.2) (Tue Feb 28 11:28:31 GMT 2023)
 
 * Add `1.0` to the list of options for required version of `search` interface, since it's apparently had a major release for some reason. Fixes ZF-85.

--- a/lib/Net/Z3950/FOLIO/PostProcess/OPAC.pm
+++ b/lib/Net/Z3950/FOLIO/PostProcess/OPAC.pm
@@ -42,7 +42,9 @@ sub processListOfFields {
 	my $field = $list->[$i];
 	my($name, $value) = @$field;
 	if (!$isItem && $name eq 'circulations') {
-	    processListOfFields($cfg, $value->[0], 1) if @$value > 0;
+	    foreach (my $j = 0; $j < @$value; $j++) {
+		processListOfFields($cfg, $value->[$j], 1);
+	    }
 	} else {
 	    my $rule = $thisCfg->{$name};
 	    if ($rule) {

--- a/t/05-postproc.t
+++ b/t/05-postproc.t
@@ -34,6 +34,10 @@ sub makeHoldings {
 	       ['itemId', '1234567890'],
 	       ['enumAndChron', 'Spring edition'],
 	   ], 'Net::z3950::FOLIO::OPACXMLRecord::item'),
+	   bless([
+	       ['itemId', '1234567891'],
+	       ['enumAndChron', 'Summer edition'],
+	   ], 'Net::z3950::FOLIO::OPACXMLRecord::item'),
       ]],
     ], 'Net::z3950::FOLIO::OPACXMLRecord::holding'),
     bless([
@@ -224,6 +228,12 @@ BEGIN {
 		enumAndChron => $censorVowels,
 	    }
 	  }, '0.circulations.0.enumAndChron', 'Spr*ng *d*t**n', 'substitute item-level field'
+	],
+	[ makeHoldings(), {
+	    circulation => {
+		enumAndChron => $censorVowels,
+	    }
+	  }, '0.circulations.1.enumAndChron', 'S*mm*r *d*t**n', 'substitute second item-level field'
 	],
 	[ makeHoldings(), {
 	    circulation => {


### PR DESCRIPTION
In previous versions, only the first was postprocessed.

Fixes ZF-86.
