### PR TITLE
MARC postproc substitution from same field instance

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,7 +3,7 @@
 ## 3.3.3 (IN PROGRESS)
 
 * Post-processing is applied to all circulations within an OPAC XML holdings record, not just the first. Fixes ZF-86.
-* When substituting into a MARC subfield from other subfields of the same field, use the values from the same instance of that field. Values from other fields and subfilds still included from the first available instance, which is what you expect. Fixes ZF-87.
+* When substituting into a MARC subfield from other subfields of the same field, use the values from the same instance of that field. Values from other fields and subfields ate still included from the first available instance, which is what you expect. Fixes ZF-87.
 
 ## [3.3.2](https://github.com/folio-org/Net-Z3950-FOLIO/tree/v3.3.2) (Tue Feb 28 11:28:31 GMT 2023)
 

--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 ## 3.3.3 (IN PROGRESS)
 
 * Post-processing is applied to all circulations within an OPAC XML holdings record, not just the first. Fixes ZF-86.
+* When substituting into a MARC subfield from other subfields of the same field, use the values from the same instance of that field. Values from other fields and subfilds still included from the first available instance, which is what you expect. Fixes ZF-87.
 
 ## [3.3.2](https://github.com/folio-org/Net-Z3950-FOLIO/tree/v3.3.2) (Tue Feb 28 11:28:31 GMT 2023)
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -28,6 +28,7 @@ doc/source-code-overview.md
 doc/srs/using-srs.md
 etc/config.able.json
 etc/config.bugfest_nolana.json
+etc/config.bugfest_orchid.json
 etc/config.chicago.json
 etc/config.dummy.json
 etc/config.fieldPerItem.json

--- a/etc/config.bugfest_orchid.json
+++ b/etc/config.bugfest_orchid.json
@@ -1,0 +1,23 @@
+{
+  "okapi": {
+    "url": "https://okapi-bugfest-orchid.int.aws.folio.org",
+    "tenant": "fs09000000"
+  },
+  "login": {
+    "username": "${OKAPI_USER-folio}",
+    "password": "${OKAPI_BUGFEST_ORCHID_PASSWORD}"
+  },
+  "marcHoldings": {
+    "fieldPerItem": true,
+    "field": "852",
+    "indicators": [" "," "],
+    "holdingsElements": {
+    },
+    "itemElements": {
+      "d": "_permanentLocation",
+      "b": "itemId",
+      "k": "_callNumberPrefix",
+      "r": "availableNow"
+    }
+  }
+}

--- a/lib/Net/Z3950/FOLIO/PostProcess/MARC.pm
+++ b/lib/Net/Z3950/FOLIO/PostProcess/MARC.pm
@@ -95,15 +95,13 @@ sub gatherMarcFields {
 
 
 sub marcFieldOrSubfield {
-    my($marc, $fieldname) = @_;
+    my($marc, $fieldname, $index) = @_;
 
     my($tag, $subtag) = ($fieldname =~ /(\d+)\$?(.*)/);
-    if ($subtag) {
-	return $marc->subfield($tag, $subtag);
-    } else {
-	my $field = $marc->field($tag);
-	return $field ? $field->data() : undef;
-    }
+    my @fields = $marc->field($tag);
+    my $field = $fields[$index || 0];
+    return undef if !$field;
+    return $subtag ? $field->subfield($subtag) : $field->data();
 }
 
 

--- a/lib/Net/Z3950/FOLIO/PostProcess/MARC.pm
+++ b/lib/Net/Z3950/FOLIO/PostProcess/MARC.pm
@@ -15,16 +15,20 @@ sub postProcessMARCRecord {
     my $newMarc = new MARC::Record();
     $newMarc->leader($marc->leader());
 
-    my $getFieldFromRecord = sub {
-	my($fieldname) = @_;
-	return (marcFieldOrSubfield($newMarc, $fieldname) ||
-		marcFieldOrSubfield($marc, $fieldname) ||
-		'');
-    };
-
     my @fields = gatherMarcFields($marc, $cfg);
+    my %fieldCountByTag = ();
     foreach my $field (@fields) {
 	my $tag = $field->tag();
+	my $fieldCount = $fieldCountByTag{$tag} || 0;
+	$fieldCountByTag{$tag} = $fieldCount+1;
+
+	my $getFieldFromRecord = sub {
+	    my($fieldname) = @_;
+	    # Use the $fieldCount'th instance of field $tag
+	    return (marcFieldOrSubfield($newMarc, $fieldname, $fieldCount) ||
+		    marcFieldOrSubfield($marc, $fieldname, $fieldCount) ||
+		    '');
+	};
 
 	my $newField;
 	if ($field->is_control_field())	{

--- a/lib/Net/Z3950/FOLIO/PostProcess/MARC.pm
+++ b/lib/Net/Z3950/FOLIO/PostProcess/MARC.pm
@@ -24,9 +24,10 @@ sub postProcessMARCRecord {
 
 	my $getFieldFromRecord = sub {
 	    my($fieldname) = @_;
-	    # Use the $fieldCount'th instance of field $tag
-	    return (marcFieldOrSubfield($newMarc, $fieldname, $fieldCount) ||
-		    marcFieldOrSubfield($marc, $fieldname, $fieldCount) ||
+
+	    # Use the $fieldCount'th instance of field $tag only if substituting from the same field
+	    return (marcFieldOrSubfield($newMarc, $fieldname, $fieldCount, $tag) ||
+		    marcFieldOrSubfield($marc, $fieldname, $fieldCount, $tag) ||
 		    '');
 	};
 
@@ -99,9 +100,10 @@ sub gatherMarcFields {
 
 
 sub marcFieldOrSubfield {
-    my($marc, $fieldname, $index) = @_;
+    my($marc, $fieldname, $index, $useIndexIfmatchTag) = @_;
 
     my($tag, $subtag) = ($fieldname =~ /(\d+)\$?(.*)/);
+    $index = 0 if defined $useIndexIfmatchTag && $tag ne $useIndexIfmatchTag;
     my @fields = $marc->field($tag);
     my $field = $fields[$index || 0];
     return undef if !$field;

--- a/t/05-postproc.t
+++ b/t/05-postproc.t
@@ -206,6 +206,10 @@ BEGIN {
 	    '952$d' => { op => 'regsub', pattern => '(.*)', replacement => '$1 %{952$v} - %{952$b}' }
 	  }, '952$d/1', 'cn2 v2 - 234', 'substitutions in second copy of a field'
 	],
+	[ $marc, {
+	    '952$d' => { op => 'regsub', pattern => '(.*)', replacement => '$1 %{952$v} - %{999$z}' }
+	  }, '952$d/1', 'cn2 v2 - water', 'substitutions in second copy from a separate field'
+	],
     );
     @postProcessHoldingsTests = (
 	# OPAC record, ruleset, field, expected, caption

--- a/t/05-postproc.t
+++ b/t/05-postproc.t
@@ -5,11 +5,13 @@ use utf8;
 use MARC::Record;
 
 sub makeMarcRecord {
+    my @fields;
+    push @fields, new MARC::Field('001', 'fire');
+    push @fields, new MARC::Field('999', '', '', z => 'water');
+    push @fields, new MARC::Field('952', '', '', d => 'cn1', v => 'v1', b => '123');
+    push @fields, new MARC::Field('952', '', '', d => 'cn2', v => 'v2', b => '234');
     my $marc = new MARC::Record();
-    my $field = new MARC::Field('999','','','z' => 'water');
-    $marc->append_fields($field);
-    my $field2 = new MARC::Field('001','fire');
-    $marc->append_fields($field2);
+    $marc->append_fields(@fields);
     # warn $marc->as_formatted();
     return $marc;
 }
@@ -194,6 +196,8 @@ BEGIN {
 	    '998$y' => [ { op => 'regsub', pattern => '^$', replacement => '%{999$x}' } ]
 	  }, '998$y', undef, 'not creating subfield by substituting empty value'
 	],
+	[ $marc, {}, '952$d/0', 'cn1', 'null transformation in first copy of a field' ],
+	[ $marc, {}, '952$d/1', 'cn2', 'null transformation in second copy of a field' ],
     );
     @postProcessHoldingsTests = (
 	# OPAC record, ruleset, field, expected, caption
@@ -293,8 +297,13 @@ foreach my $transformTest (@transformTests) {
 
 foreach my $postProcessMarcTest (@postProcessMarcTests) {
     my($marc, $cfg, $field, $expected, $caption) = @$postProcessMarcTest;
+    my $index;
+    if ($field =~ /(.*)\/(.*)/) {
+	$field = $1;
+	$index = $2;
+    }
     my $newMarc = postProcessMARCRecord($cfg, $marc);
-    my $got = marcFieldOrSubfield($newMarc, $field);
+    my $got = marcFieldOrSubfield($newMarc, $field, $index);
     is($got, $expected, "postProcessMARCRecord field $field ($caption)");
 }
 

--- a/t/05-postproc.t
+++ b/t/05-postproc.t
@@ -198,6 +198,10 @@ BEGIN {
 	],
 	[ $marc, {}, '952$d/0', 'cn1', 'null transformation in first copy of a field' ],
 	[ $marc, {}, '952$d/1', 'cn2', 'null transformation in second copy of a field' ],
+	[ $marc, {
+	    '952$d' => { op => 'regsub', pattern => '(.*)', replacement => '$1 %{952$v} - %{952$b}' }
+	  }, '952$d/0', 'cn1 v1 - 123', 'substitutions in first copy of a field'
+	],
     );
     @postProcessHoldingsTests = (
 	# OPAC record, ruleset, field, expected, caption

--- a/t/05-postproc.t
+++ b/t/05-postproc.t
@@ -202,6 +202,10 @@ BEGIN {
 	    '952$d' => { op => 'regsub', pattern => '(.*)', replacement => '$1 %{952$v} - %{952$b}' }
 	  }, '952$d/0', 'cn1 v1 - 123', 'substitutions in first copy of a field'
 	],
+	[ $marc, {
+	    '952$d' => { op => 'regsub', pattern => '(.*)', replacement => '$1 %{952$v} - %{952$b}' }
+	  }, '952$d/1', 'cn2 v2 - 234', 'substitutions in second copy of a field'
+	],
     );
     @postProcessHoldingsTests = (
 	# OPAC record, ruleset, field, expected, caption


### PR DESCRIPTION
When performing post-processing on MARC records, substitution replacement strings that contain sequences of the form `%{999$z}` are now treated slightly differently. If the field replacement value is to be drawn from another subfield of the field that is being modified, then the value is taken from the same instance of the field (as there may be several — as for example when the represent multiple items in holdings). When the value is to be drawn from a different field, then the first instance of that field is references as previously.

New test-cases added.

Fixes ZF-87.