### PR TITLE
Fix typo (but see full comment)

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,7 +3,7 @@
 ## 3.3.3 (IN PROGRESS)
 
 * Post-processing is applied to all circulations within an OPAC XML holdings record, not just the first. Fixes ZF-86.
-* When substituting into a MARC subfield from other subfields of the same field, use the values from the same instance of that field. Values from other fields and subfields ate still included from the first available instance, which is what you expect. Fixes ZF-87.
+* When substituting into a MARC subfield from other subfields of the same field, use the values from the same instance of that field. Values from other fields and subfields are still included from the first available instance, which is what you expect. Fixes ZF-87.
 
 ## [3.3.2](https://github.com/folio-org/Net-Z3950-FOLIO/tree/v3.3.2) (Tue Feb 28 11:28:31 GMT 2023)
 


### PR DESCRIPTION
Yes, I fixed a one-character typo in the change-log. But the real reason for this commit is so I can include in the git log the comment that I intended for the previous, much more substantial, commit -- but which got lost because I rushed through GitHub's merge process and didn't realise it had written its own ugly comment in place of the one I had written for the pull request. So here it is:

--

MARC postproc substitution from same field instance #39

When performing post-processing on MARC records, substitution replacement strings that contain sequences of the form `%{999$z}` are now treated slightly differently. If the field replacement value is to be drawn from another subfield of the field that is being modified, then the value is taken from the same instance of the field (as there may be several — as for example when the represent multiple items in holdings). When the value is to be drawn from a different field, then the first instance of that field is references as previously.

New test-cases added.

Fixes ZF-87.