### PR TITLE
Zf 84  holdings statements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 
 * Make source of availableThru value in OPAC record configurable. Fixes ZF-90.
 * Add support for stripping ligatures and modifier letters to stripDiacritics. Fixes ZF-92.
+* Include holdings "holdings statement" data in z39.50 XML. Fixes ZF-84.
 
 ## [3.3.5](https://github.com/folio-org/Net-Z3950-FOLIO/tree/v3.3.5)(Tue Oct 20 19:52:37 EDT 2023)
 

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,7 @@
 
 * Make source of availableThru value in OPAC record configurable. Fixes ZF-90.
 * Add support for stripping ligatures and modifier letters to stripDiacritics. Fixes ZF-92.
-* Include holdings "holdings statement" data in z39.50 XML. Fixes ZF-84.
+* Include holdings "holdings statement" data in OPAC and OPACXML records. Fixes ZF-84.
 
 ## [3.3.5](https://github.com/folio-org/Net-Z3950-FOLIO/tree/v3.3.5)(Tue Oct 20 19:52:37 EDT 2023)
 

--- a/etc/mod-search.graphql-query
+++ b/etc/mod-search.graphql-query
@@ -24,6 +24,21 @@ query($cql: String, $offset: Int, $limit: Int) {
           holdingsNoteType { name }
           note
         }
+        holdingsStatements {
+          statement
+          note
+          staffNote
+        }
+        holdingsStatementsForIndexes {
+          statement
+          note
+          staffNote
+        }
+        holdingsStatementsForSupplements {
+          statement
+          note
+          staffNote
+        }
         bareHoldingsItems {
           discoverySuppress
           status { name }

--- a/lib/Net/Z3950/FOLIO/HoldingsRecords.pm
+++ b/lib/Net/Z3950/FOLIO/HoldingsRecords.pm
@@ -156,7 +156,7 @@ sub _makePublicNote {
 
 sub _holdingsStatements {
     my($statements, $caption) = @_;
-    return undef if !defined $statements;
+    return undef if !defined $statements || @$statements == 0;
 
     my @res = map {
 	my $s = $statements->[$_-1];

--- a/lib/Net/Z3950/FOLIO/HoldingsRecords.pm
+++ b/lib/Net/Z3950/FOLIO/HoldingsRecords.pm
@@ -78,8 +78,8 @@ sub _makeSingleHoldingsRecord {
         [ '_callNumberSuffix', $holding->{callNumberSuffix} ],
         [ 'shelvingData', _makeShelvingData($holding) ],
         [ 'copyNumber', $holding->{copyNumber} ], # 852 $t
-        [ 'publicNote', _noteOfType($holding->{notes}, qr/public/i) ], # 852 $z
-        [ 'reproductionNote', _noteOfType($holding->{notes}, qr/reproduction/i) ], # 843
+        [ 'publicNote', _makePublicNote($holding) ], # 852 $z
+        [ 'reproductionNote', _notesOfType($holding->{notes}, qr/reproduction/i) ], # 843
         [ 'termsUseRepro', _makeTermsUseRepro($marc) ], # 845
         [ 'circulations', $itemObjects, undef, 1 ],
     ], 'Net::z3950::FOLIO::OPACXMLRecord::holding';
@@ -118,6 +118,67 @@ sub _makeShelvingData {
 }
 
 
+# This field is rather overloaded. It must contain not only holdings
+# notes of type "public" and similar, but also any holdings statements
+# (each potentially consisting of statement, note and staffNote) along
+# with the same thing for holdingsStatementsForSupplements and
+# holdingsStatementsForIndexes.
+#
+# Here's how we do this:
+# * Each entry is newline-separated
+# * Each holdings statement is included
+# * Each holdings-for-supplements statement is included, prefixed with "SUPPLEMENT: "
+# * Each holdings-for-indexes statement is included, prefixed with "INDEX: "
+# * Any public notes are included
+#
+# When there is more than one statement in any of the categories
+# (holdings, holdings for supplements, holdings for indexes), they are
+# all numbered within that category. When there is only one statement
+# in a category, it is not numbered.
+#
+# This means that in the common case of a single holdings statement,
+# it will appear alone and unadorned.
+
+sub _makePublicNote {
+    my($holding) = @_;
+
+    my @notes;
+    push @notes, _holdingsStatements($holding->{holdingsStatements}, undef);
+    push @notes, _holdingsStatements($holding->{holdingsStatementsForSupplements}, "SUPPLEMENT");
+    push @notes, _holdingsStatements($holding->{holdingsStatementsForIndexes}, "INDEX");
+    push @notes, _notesOfType($holding->{notes}, qr/public/i);
+
+    @notes = grep { defined } @notes;
+    return undef if @notes == 0;
+    return join("\n", @notes);
+}
+
+
+sub _holdingsStatements {
+    my($statements, $caption) = @_;
+    return undef if !defined $statements;
+
+    my @res = map {
+	my $s = $statements->[$_-1];
+	my $res;
+	if (defined $caption && @$statements > 1) {
+	    $res = "$caption $_: ";
+	} elsif (defined $caption) {
+	    $res = "$caption: ";
+	} elsif (@$statements > 1) {
+	    $res = "$_: ";
+	}
+
+	$res .= $s->{statement};
+	$res .= " [NOTE: " . $s->{note} . "]" if $s->{note};
+	$res .= " [STAFF NOTE: " . $s->{staffNote} . "]" if $s->{staffNote};
+	$res;
+    } 1..@$statements;
+
+    return join("\n", @res);
+}
+
+
 # In the FOLIO inventory model, instances, holdings records and items
 # can all have a set of zero or more notes, each of which has a note
 # type. These note types are drawn from three separate vocabularies
@@ -129,17 +190,22 @@ sub _makeShelvingData {
 # known UUIDS -- and pull out the text of notes of the appropriate
 # type.
 #
-# For this to work, though, we will need mod-graphql to populate the
-# note-type objects.
+# When there is more than one note of a given type, we return a single
+# string containing each note on a line of its own preceded by its
+# ordinal number. This number is omitted when there is a single note.
 #
-sub _noteOfType {
+sub _notesOfType {
     my($notes, $regexp) = @_;
 
+    my @notes;
     foreach my $note (@$notes) {
 	my $type = $note->{holdingsNoteType};
-	return $note->{note} if $type && $type->{name} =~ $regexp;
+	push @notes, $note->{note} if $type && $type->{name} =~ $regexp;
     }
-    return undef;
+
+    return undef if @notes == 0;
+    return $notes[0] if @notes == 1;
+    return join("\n", map { "$_: " . $notes[$_-1] } 1..@notes);
 }
 
 
@@ -336,7 +402,7 @@ sub _makeYearCaption {
 
 
 use Exporter qw(import);
-our @EXPORT_OK = qw(makeHoldingsRecords);
+our @EXPORT_OK = qw(makeHoldingsRecords _makeSingleHoldingsRecord);
 
 
 1;

--- a/t/data/records/expectedOutput2.xml
+++ b/t/data/records/expectedOutput2.xml
@@ -28,6 +28,13 @@
       <localLocation>Simmons University Library</localLocation>
       <shelvingLocation>Online Library Resources</shelvingLocation>
       <callNumber>G1046.C3&lt;L56&gt;2009eb</callNumber>
+      <publicNote>1: First statement [NOTE: Added by Mike] [STAFF NOTE: For Z39.50 testing]
+2: Second statement [NOTE: Mike again]
+3: Third statement [STAFF NOTE: Most people should ignore this note]
+4: Fourth statement
+SUPPLEMENT 1: First holdings statement for supplements [NOTE: Why do we want this?]
+SUPPLEMENT 2: Second supplementary HS [STAFF NOTE: Staff should enjoy this]
+INDEX: First HS for indexes [NOTE: What even IS an HS for indexes?]</publicNote>
       <reproductionNote>May be freely copied</reproductionNote>
       <termsUseRepro>$3Bituminous Coal Division and National Bituminous Coal Commission Records$a&quot;No information obtained from a producer disclosing cost of production or sales realization shall be made public without the consent of the producer from whom the same shall have been obtained&quot;;$c50 Stat.88.</termsUseRepro>
       <circulations>

--- a/t/data/records/input2.json
+++ b/t/data/records/input2.json
@@ -76,9 +76,47 @@
         "yearCaption": []
       }
     ],
-    "holdingsStatements": [],
-    "holdingsStatementsForIndexes": [],
-    "holdingsStatementsForSupplements": [],
+    "holdingsStatements": [
+      {
+        "note": "Added by Mike",
+        "staffNote": "For Z39.50 testing",
+        "statement": "First statement"
+      },
+      {
+        "note": "Mike again",
+        "staffNote": "",
+        "statement": "Second statement"
+      },
+      {
+        "note": "",
+        "staffNote": "Most people should ignore this note",
+        "statement": "Third statement"
+      },
+      {
+        "note": "",
+        "staffNote": "",
+        "statement": "Fourth statement"
+      }
+    ],
+    "holdingsStatementsForIndexes": [
+      {
+        "note": "What even IS an HS for indexes?",
+        "staffNote": "",
+        "statement": "First HS for indexes"
+      }
+    ],
+    "holdingsStatementsForSupplements": [
+      {
+        "note": "Why do we want this?",
+        "staffNote": "",
+        "statement": "First holdings statement for supplements"
+      },
+      {
+        "note": "",
+        "staffNote": "Staff should enjoy this",
+        "statement": "Second supplementary HS"
+      }
+    ],
     "holdingsTypeId": null,
     "hrid": "b2245518-elere",
     "id": "697448a8-a428-11ea-b7fc-94e55e224816",
@@ -86,16 +124,6 @@
     "instanceId": "2ff48cb6-a41c-11ea-8d99-9ee25e224816",
     "metadata": null,
     "notes": [
-      {
-        "holdingsNoteType": {
-          "id": "a336ce03-f68a-4875-b82a-4f21df8139c5",
-          "name": "Bound with",
-          "source": "local"
-        },
-        "holdingsNoteTypeId": "a336ce03-f68a-4875-b82a-4f21df8139c5",
-        "note": "This is a holdings note",
-        "staffOnly": false
-      },
       {
         "holdingsNoteType": {
           "id": "6a41b714-8574-4084-8d64-a9373c3fbb59",


### PR DESCRIPTION
Include holdings statements in OPAC/OPACXML records.

This is quite complex due to the involved structures in the FOLIO records. See the comment on the function `_makePublicNote` in lib/Net/Z3950/FOLIO/HoldingsRecords.pm

Fixes ZF-84.