### PR TITLE
New-style FOLIO authentication with expiry and refresh

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Revision history for Perl extension Net::Z3950::FOLIO.
 
+## 4.0.0 (IN PROGRESS)
+
+* **Breaking change**: uses new-style FOLIO authentication with expiring-and-refreshing tokens instead of old-style authentication, which is deprecated. This version of the Z39.50 server is fine to use with any FOLIO back-end based on release Poppy or later; prior versions (v3.4.0 and earlier) **will no longer work** with FOLIO back-ends based on release Ramsons or later. Fixes ZF-91.
+
 ## 3.4.0 (Fri  9 Feb 2024 16:47:17 GMT)
 
 * Make source of availableThru value in OPAC record configurable. Fixes ZF-90.

--- a/Changes.md
+++ b/Changes.md
@@ -187,5 +187,5 @@
 
 ## To do
 
-* Determine FOLIO tenant from database name, and postpone initialisation and authentication until we know that (ZF-2).
 * Automatic generation of MARC records (ZF-14). Thi will need a non-trivial version of `etc/folio2marcxml.xsl` (ZF-8).
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update \
  && cpan Cpanel::JSON::XS \
  && cpan LWP::UserAgent \
  && cpan LWP::Protocol::https \
+ && cpan HTTP::Cookies \
+ && cpan DateTime \
  && cpan Mozilla::CA \
  && cpan MARC::Record \
  && cpan Net::Z3950::PQF \

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,6 +9,7 @@ WriteMakefile(
 	Net::Z3950::SimpleServer => 1.21,
 	LWP::UserAgent => 6.05,
 	LWP::Protocol::https => 6.04,
+	HTTP::Cookies => 6.10,
 	Mozilla::CA => 20200520,
 	Cpanel::JSON::XS => 4.08,
 	MARC::Record => 2.0,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,6 +10,7 @@ WriteMakefile(
 	LWP::UserAgent => 6.05,
 	LWP::Protocol::https => 6.04,
 	HTTP::Cookies => 6.10,
+	DateTime => 1.65,
 	Mozilla::CA => 20200520,
 	Cpanel::JSON::XS => 4.08,
 	MARC::Record => 2.0,

--- a/lib/Net/Z3950/FOLIO.pm
+++ b/lib/Net/Z3950/FOLIO.pm
@@ -157,6 +157,7 @@ sub _search_handler {
 
     my $session = $ghandle->getSession($base);
     $args->{HANDLE} = $session;
+    $session->maybeRefreshToken();
 
     if ($args->{CQL}) {
 	$session->{cql} = $args->{CQL};
@@ -174,6 +175,7 @@ sub _search_handler {
 sub _fetch_handler {
     my($args) = @_;
     my $session = $args->{HANDLE};
+    $session->maybeRefreshToken();
 
     my $rs = $session->{resultsets}->{$args->{SETNAME}};
     _throw(30, $args->{SETNAME}) if !$rs; # Result set does not exist
@@ -237,6 +239,7 @@ sub _fetch_handler {
 sub _delete_handler {
     my($args) = @_;
     my $session = $args->{HANDLE};
+    $session->maybeRefreshToken();
 
     my $setname = $args->{SETNAME};
     if ($session->{resultsets}->{$setname}) {
@@ -251,8 +254,8 @@ sub _delete_handler {
 
 sub _sort_handler {
     my($args) = @_;
-    my $ghandle = $args->{GHANDLE};
     my $session = $args->{HANDLE};
+    $session->maybeRefreshToken();
 
     my $setnames = $args->{INPUT};
     _throw(230, '1') if @$setnames > 1; # Sort: too many input results

--- a/lib/Net/Z3950/FOLIO.pm
+++ b/lib/Net/Z3950/FOLIO.pm
@@ -8,6 +8,7 @@ use Cpanel::JSON::XS qw(decode_json encode_json);
 use Net::Z3950::SimpleServer;
 use ZOOM; # For ZOOM::Exception
 use LWP::UserAgent;
+use HTTP::Cookies;
 use MARC::Record;
 use MARC::File::XML (BinaryEncoding => 'utf8', RecordFormat => 'USMARC');
 use Data::Dumper; $Data::Dumper::Indent = 1;
@@ -66,13 +67,17 @@ sub new {
     my $class = shift();
     my($cfgbase) = @_;
 
+    my $ua = new LWP::UserAgent();
+    my $jar = HTTP::Cookies->new();
+    $ua->cookie_jar($jar);
+    $ua->agent("z2folio $VERSION");
+
     my $this = bless {
 	cfgbase => $cfgbase || 'config',
-	ua => new LWP::UserAgent(),
+	ua => $ua,
 	sessions => {}, # Maps database name to session object
     }, $class;
 
-    $this->{ua}->agent("z2folio $VERSION");
     $this->{server} = Net::Z3950::SimpleServer->new(
 	GHANDLE => $this,
 	INIT =>    \&_init_handler_wrapper,

--- a/lib/Net/Z3950/FOLIO.pm
+++ b/lib/Net/Z3950/FOLIO.pm
@@ -67,14 +67,8 @@ sub new {
     my $class = shift();
     my($cfgbase) = @_;
 
-    my $ua = new LWP::UserAgent();
-    my $jar = HTTP::Cookies->new();
-    $ua->cookie_jar($jar);
-    $ua->agent("z2folio $VERSION");
-
     my $this = bless {
 	cfgbase => $cfgbase || 'config',
-	ua => $ua,
 	sessions => {}, # Maps database name to session object
     }, $class;
 

--- a/lib/Net/Z3950/FOLIO/Session.pm
+++ b/lib/Net/Z3950/FOLIO/Session.pm
@@ -43,7 +43,7 @@ sub login {
     _throw(1014, "credentials not supplied")
 	if !defined $username || !defined $password;
 
-    my $url = $cfg->{okapi}->{url} . '/bl-users/login';
+    my $url = $cfg->{okapi}->{url} . '/authn/login-with-expiry';
     my $req = $this->_makeHTTPRequest(POST => $url);
     $req->content(qq[{ "username": "$username", "password": "$password" }]);
     # warn "req=", $req->content();
@@ -52,7 +52,8 @@ sub login {
     _throw(1014, $res->content())
 	if !$res->is_success();
 
-    $this->{token} = $res->header('X-Okapi-token');
+    my $json = decode_json($res->content());
+    $this->{accessTokenExpiration} = $json->{accessTokenExpiration};
 }
 
 
@@ -274,7 +275,6 @@ sub _makeHTTPRequest() {
     $req->header('X-Okapi-tenant' => $this->{cfg}->{okapi}->{tenant});
     $req->header('Content-type' => 'application/json');
     $req->header('Accept' => 'application/json');
-    $req->header('X-Okapi-token' => $this->{token}) if $this->{token};
     return $req;
 }
 

--- a/lib/Net/Z3950/FOLIO/Session.pm
+++ b/lib/Net/Z3950/FOLIO/Session.pm
@@ -53,7 +53,22 @@ sub login {
 	if !$res->is_success();
 
     my $json = decode_json($res->content());
-    $this->{accessTokenExpiration} = $json->{accessTokenExpiration};
+    my $isoString = $json->{accessTokenExpiration};
+    # Format: 2024-07-02T16:48:56Z
+    my $match = ($isoString =~ /(\d\d\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)Z/);
+    _throw(2, "Non-ISO date returned as accessTokenExpiration: $isoString")
+	if !$match;
+
+    my($year, $mon, $mday, $hour, $min, $sec) = $match;
+    my $dt = new DateTime(
+	year       => $year,
+	month      => $mon,
+	day        => $mday,
+	hour       => $hour,
+	minute     => $min,
+	second     => $sec,
+    );
+    $this->{accessTokenExpiration} = $dt;
 }
 
 


### PR DESCRIPTION
**This is a breaking change**: the FOLIO Z39.50 server now uses new-style FOLIO authentication with expiring-and-refreshing tokens instead of old-style authentication, which is deprecated. This version of the Z39.50 server is fine to use with any FOLIO back-end based on release Poppy or later but will not work with Nolana or earlier. Prior versions (v3.4.0 and earlier) **will no longer work** with FOLIO back-ends based on release Ramsons or later.

Fixes ZF-91.