### PR TITLE
Back down an unnecessarily recent dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,6 +2,7 @@ use 5.008000;
 use ExtUtils::MakeMaker;
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
+
 WriteMakefile(
     NAME              => 'Net::Z3950::FOLIO',
     VERSION_FROM      => 'lib/Net/Z3950/FOLIO.pm', # finds $VERSION

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,7 @@ WriteMakefile(
 	Net::Z3950::SimpleServer => 1.21,
 	LWP::UserAgent => 6.05,
 	LWP::Protocol::https => 6.04,
-	HTTP::Cookies => 6.10,
+	HTTP::Cookies => 6.08,
 	DateTime => 1.65,
 	Mozilla::CA => 20200520,
 	Cpanel::JSON::XS => 4.08,


### PR DESCRIPTION
When I added a dependency on HTTP::Cookies, I set it to 6.10 because that's what was on the development machine I happened to be using. But on another developement machine I only have 6.08, and that works just fine. So I wound the dependency back to avoid an ugly (but benign) warning.