### PR TITLE
Reject fetch before search

### DIFF
--- a/lib/Net/Z3950/FOLIO.pm
+++ b/lib/Net/Z3950/FOLIO.pm
@@ -175,6 +175,8 @@ sub _search_handler {
 sub _fetch_handler {
     my($args) = @_;
     my $session = $args->{HANDLE};
+    _throw(30, $args->{SETNAME}) if !$session;
+
     $session->maybeRefreshToken();
 
     my $rs = $session->{resultsets}->{$args->{SETNAME}};


### PR DESCRIPTION
Previously, if a client started a new session and issued a fetch request before having searched, the server would try to access a not-yet-existent session object, and crash. Now, such requests are detected and rejected politely.