### PR TITLE
Optionally include item availability date in responses

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 ## 4.0.1 (IN PROGRESS)
 
 * Side-loading mod-graphql now works under RTR. Fixes ZF-108.
+* Information about loans (specifically, availability date) can be obtained by using an extended database name: see [**Obtaining information about loans** in the top-level `README.md`](README.md#obtaining-information-about-loans) for details. Fixes ZF-96.
 
 ## 4.0.0 (Thu  4 Jul 17:34:07 BST 2024)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # z2folio - the Z39.50-to-FOLIO gateway
 
-Copyright (C) 2018-2021 The Open Library Foundation
+Copyright (C) 2018-2024 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
@@ -13,6 +13,7 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 * [Building and running from Docker](#building-and-running-from-docker)
 * [Authentication](#authentication)
 * [Access via SRU](#access-via-sru)
+* [Obtaining information about loans](#obtaining-information-about-loans)
 * [Troubleshooting](#troubleshooting)
 * [Additional information](#additional-information)
     * [Other documentation](#other-documentation)
@@ -81,6 +82,16 @@ Whichever approach to running the server you prefer, the [default configuration 
 Thanks to the magic of the protocol-polyglot [YAZ GFS](https://software.indexdata.com/yaz/doc/server.html), the FOLIO Z39.50 server also serves the SRU (REST-like) and SRW (SOAP-based) protocols. For example, if running the server on your local host, you can use the following to obtain an XML-formatted OPAC record containing both bibliographic metadata in MARCXML format and holdings-and-item information such as might be used by an OPAC. Replace placeholder <dbname> with the real database name (or tenant id).
 
     http://localhost:9997/<dbname>?version=1.1&operation=searchRetrieve&query=title=a&maximumRecords=1&recordSchema=opac
+
+## Obtaining information about loans
+
+The Z39.50 server obtains information about the holdings and items associated with each instance record from FOLIO using `mod-graphql`, which behind the scenes performs searches for each holding record associated with the instance, and for each item in each of those holdings -- returning the aggregated tree-shaped record. This process can be expensive on the back-end.
+
+In order to obtain information about loans -- specifically, the availability date of those items that are on loan -- it is unfortunately necessary to have `mod-graphql` run yet another search for each item in the response, fetching information about that item's open loans. For records with many items, this is likely to nearly double the load on the back-end system, and the response time when fetching the record.
+
+Rather than impose this burden on all users of the FOLIO Z39.50 service, the default configuration does not request information about loans. However, as well as the regular GraphQL query `mod-search.graphql-query`, which is used by the default Z39.50 server configuration, the supplied set of configuration files also includes `etc/mod-search-with-loans.graphql-query`, which is identical except that it _does_ request the loan information. Clients that need availability dates should use this extended version of the GraphQL query. The easiest way to do this is to append the string `|withLoans` to the end of the Z39.50 database name: for example, instead of the database name `books`, use `books|withLoans`. This version of the database will include the `availabilityDate` field in its OPAC records.
+
+Fetching information about loans requires the FOLIO installation to provide version 1.4 or better of the `graphql` interface, most likely though `mod-graphql` version 1.13.1 or higher.
 
 ## Troubleshooting
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -17,7 +17,7 @@
   "requires": [
     {
       "id": "graphql",
-      "version": "1.3"
+      "version": "1.4"
     },
     {
       "id": "search",

--- a/etc/config.withLoans.json
+++ b/etc/config.withLoans.json
@@ -1,0 +1,3 @@
+{
+  "graphqlQuery": "mod-search-with-loans.graphql-query"
+}

--- a/etc/mod-search-with-loans.graphql-query
+++ b/etc/mod-search-with-loans.graphql-query
@@ -1,0 +1,85 @@
+query($cql: String, $offset: Int, $limit: Int) {
+  search_instances(query: $cql, offset: $offset, limit: $limit) {
+    totalRecords
+    instances {
+      id
+      hrid title # Not used by the Z-server but useful for debugging
+      holdingsRecords2 {
+        temporaryLocation {
+          institution { name }
+          library { name }
+          name
+        }
+        permanentLocation {
+          institution { name }
+          library { name }
+          name
+        }
+        callNumberPrefix
+        callNumber
+        callNumberSuffix
+        shelvingTitle
+        copyNumber
+        notes {
+          holdingsNoteType { name }
+          note
+        }
+        holdingsStatements {
+          statement
+          note
+          staffNote
+        }
+        holdingsStatementsForIndexes {
+          statement
+          note
+          staffNote
+        }
+        holdingsStatementsForSupplements {
+          statement
+          note
+          staffNote
+        }
+        bareHoldingsItems {
+          discoverySuppress
+          status { name }
+          loans {
+            dueDate
+            borrower { barcode firstName lastName }
+            status { name }
+          }
+          materialType { name }
+          barcode
+          enumeration
+          chronology
+          temporaryLocation {
+            name
+            institution { name }
+            campus { name }
+            library { name }
+            primaryServicePointObject { name }
+          }
+          permanentLocation {
+            name
+            institution { name }
+            campus { name }
+            library { name }
+            primaryServicePointObject { name }
+          }
+          effectiveCallNumberComponents {
+            callNumber
+            prefix
+            suffix
+          }
+          volume
+          yearCaption
+          accessionNumber
+          copyNumber
+          descriptionOfPieces
+          hrid
+          id
+          itemIdentifier
+        }
+      }
+    }
+  }
+}

--- a/lib/Net/Z3950/FOLIO/HoldingsRecords.pm
+++ b/lib/Net/Z3950/FOLIO/HoldingsRecords.pm
@@ -305,13 +305,10 @@ sub _makeAvailableNow {
 }
 
 
-# Availability Date is not in the FOLIO inventory data. It should be
-# possible to obtain it as the Due Date in mod-circulation, if we want
-# to add the necessary extra queries.
-#
 sub _makeAvailabilityDate {
     my($item) = @_;
-    return undef; # XXX for now
+
+    return $item->{loans} && $item->{loans}->{dueDate};
 }
 
 


### PR DESCRIPTION
Information about loans (specifically, availability date) can be obtained by using an extended database name: see **Obtaining information about loans** in the top-level `README.md` for details.

Fixes ZF-96.