### PR TITLE
Update module descriptor' dependencies

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Revision history for Perl extension Net::Z3950::FOLIO.
 
+## 4.0.2 (IN PROGRESS)
+
+* Update module descriptor to depend on `login` interface (and not to depend on `search`). Fixes ZF-98.
+
 ## 4.0.1 (Thu  5 Dec 2024 17:06:48 GMT)
 
 * Side-loading mod-graphql now works under RTR. Fixes ZF-108.

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -16,12 +16,12 @@
   ],
   "requires": [
     {
-      "id": "graphql",
-      "version": "1.4"
+      "id": "login",
+      "version": "7.3"
     },
     {
-      "id": "search",
-      "version": "0.7 0.8 0.9 1.0"
+      "id": "graphql",
+      "version": "1.4"
     },
     {
       "id": "source-storage-source-records",


### PR DESCRIPTION
Now depends on `login` interface and does _not_ depend on `search`.

Fixes ZF-98.