### PR TITLE
[ZF-110] More than 10 holdings and items

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Revision history for Perl extension Net::Z3950::FOLIO.
 
+## 4.1.1 (IN PROGRESS)
+
+* Reinstate ability to fetch more than 10 holdings records, and more than 10 items within a holdings area, as was originally fixed in ZF-42 but inadvertently regressed in the move to mod-search (ZF-62). This time, it fixes ZF-110.
+
 ## 4.1.0 (Thu 13 Mar 2025 13:59:46 GMT)
 
 * Update module descriptor to depend on `login` interface (and not to depend on `search`). Fixes ZF-98.

--- a/etc/mod-search.graphql-query
+++ b/etc/mod-search.graphql-query
@@ -4,7 +4,7 @@ query($cql: String, $offset: Int, $limit: Int) {
     instances {
       id
       hrid title # Not used by the Z-server but useful for debugging
-      holdingsRecords2 {
+      holdingsRecords2(limit: 100) {
         temporaryLocation {
           institution { name }
           library { name }
@@ -39,7 +39,7 @@ query($cql: String, $offset: Int, $limit: Int) {
           note
           staffNote
         }
-        bareHoldingsItems {
+        bareHoldingsItems(limit: 100) {
           discoverySuppress
           status { name }
           materialType { name }


### PR DESCRIPTION
Reinstate ability to fetch more than 10 holdings records, and more than 10 items within a holdings area, as was originally fixed in ZF-42 but inadvertently regressed in the move to mod-search (ZF-62).