### PR TITLE
[ZF-112] FOLIO ID of MARC record can be in $i of any 999ff field

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Revision history for Perl extension Net::Z3950::FOLIO.
 
+## 4.1.2
+
+* When a MARC record has multiple 999ff fields, the FOLIO ID will now be taken from the first of these that has a `$i` subfield, rather than always using the last. This means that composite records from ETL process, which may have multiple 999ff fields, can now be retrieved. Fixes ZF-112.
+
 ## 4.1.1 (Mon 24 Mar 2025 12:53:38 GMT)
 
 * Reinstate ability to fetch more than 10 holdings records, and more than 10 items within a holdings area, as was originally fixed in ZF-42 but inadvertently regressed in the move to mod-search (ZF-62). This time, it fixes ZF-110.

--- a/lib/Net/Z3950/FOLIO/Record.pm
+++ b/lib/Net/Z3950/FOLIO/Record.pm
@@ -65,8 +65,11 @@ sub _marc2folioId {
     my $marc = shift;
 
     my @fields999 = $marc->field(999);
-    my $last999 = $fields999[-1];
-    return $last999->subfield('i');
+    foreach my $field999 (@fields999) {
+	my $folioId = $field999->subfield('i');
+	return $folioId if $folioId;
+    }
+    return undef;
 }
 
 sub marcRecord {
@@ -83,6 +86,7 @@ sub marcRecord {
 	for (my $i = 0; $i < @marcRecords; $i++) {
 	    my $marc = $marcRecords[$i];
 	    my $id = _marc2folioId($marc);
+	    Net::Z3950::FOLIO::_throw(1, "can't find FOLIO ID in MARC record", undef, 1) if !defined $id;
 	    my $rec = $rs->recordById($id);
 	    $rec->{marc} = $marcRecords[$i];
 	}

--- a/lib/Net/Z3950/FOLIO/Session.pm
+++ b/lib/Net/Z3950/FOLIO/Session.pm
@@ -72,7 +72,6 @@ sub _setRefreshTokenExpiration {
     my $minEpoch = $refreshTokenEpoch < $accessTokenEpoch ? $refreshTokenEpoch : $accessTokenEpoch;
     my $nowEpoch = DateTime->now()->epoch();
     my $secs = $minEpoch - $nowEpoch;
-    warn 'refresh token expires in ', $refreshTokenEpoch-$nowEpoch, ' seconds, access token in ', $accessTokenEpoch-$nowEpoch;
 
     # Choose when to get a new token, based on when the shorter-lived
     # of the two tokens expires. One simple option would be when half


### PR DESCRIPTION
When a MARC record has multiple 999ff fields, the FOLIO ID will now be taken from the first of these that has a `$i` subfield, rather than always using the last. This means that composite records from ETL process, which may have multiple 999ff fields, can now be retrieved.