### PR TITLE
Release v4.2.0

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,6 @@
 # Revision history for Perl extension Net::Z3950::FOLIO.
 
-## 4.1.2
+## 4.2.0 (Wed 18 Jun 2025 12:33:06 CEST)
 
 * When a MARC record has multiple 999ff fields, the FOLIO ID will now be taken from the first of these that has a `$i` subfield, rather than always using the last. This means that composite records from ETL process, which may have multiple 999ff fields, can now be retrieved. Fixes ZF-112.
 * New `holdingsInEachItem` configuration entry causes each item's field in MARC holdings to carry its own copy of the holdings fields. Fixes ZF-105.

--- a/lib/Net/Z3950/FOLIO.pm
+++ b/lib/Net/Z3950/FOLIO.pm
@@ -19,7 +19,7 @@ use Net::Z3950::FOLIO::RPN;
 use Net::Z3950::FOLIO::SurrogateDiagnostic;
 
 
-our $VERSION = 'v4.1.1';
+our $VERSION = 'v4.2.0';
 
 
 sub FORMAT_USMARC { '1.2.840.10003.5.10' }


### PR DESCRIPTION
Release v4.2.0 was created from branch `b4.2`, but it seems I unthinkingly deleted that branch — and, worse, before it was merged to master, which consequently trails the current most recent release.

To fix this, I created a new version of branch `b4.2` from the release tag `v4.2.0`, and am now merging back into `master`.