### PR TITLE
[ZF-122] MARC holdings records appear even when no items

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 * Add holdings `hrid` to the GraphQL query. (Related to ZF-114.)
 * Upgrade Docker base image from Debian bullseye to trixie. Fixes ZF-120.
 * Update MODS mapping, and add new DC (Dublin Core) mapping. Both due to Marko Knepper! Fixes ZF-121.
+* If a holdings record has no items, generated MARC holdings still includes holdings fields. Fixes regression ZF-122.
 
 ## 4.3.0 (Fri 19 Sep 2025 18:25:22 BST)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,23 +2,18 @@ FROM debian:trixie AS base
 
 WORKDIR /usr/src/app
 
-RUN  rm -rf /var/lib/apt/lists/* \
-  && apt clean \
-  && apt update \
-  && apt install -y \
+RUN  apt-get update \
+  && apt-get install -y \
       apt-transport-https \
       ca-certificates \
       gnupg \
-      wget
-
-RUN mkdir -p /etc/apt/keyrings \
+      wget \
+  && mkdir -p /etc/apt/keyrings \
   && wget https://ftp.indexdata.com/debian/indexdata.asc -O /etc/apt/keyrings/indexdata.asc \
-  && echo 'deb [signed-by=/etc/apt/keyrings/indexdata.asc] https://download.indexdata.com/debian trixie main' > /etc/apt/sources.list.d/indexdata.list \
-  && rm -rf /var/lib/apt/lists/* \
-  && apt clean \
-  && apt update \
-  # && apt upgrade -y \
-  && apt install -y \
+  && echo 'deb [signed-by=/etc/apt/keyrings/indexdata.asc] https://ftp.indexdata.com/debian trixie main' > /etc/apt/sources.list.d/indexdata.list \
+  && apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y \
       build-essential \
       gcc \
       libexpat1-dev \
@@ -34,9 +29,8 @@ RUN mkdir -p /etc/apt/keyrings \
       libdatetime-perl \
       libmarc-record-perl \
       libtest-differences-perl \
-      libxml-xslt-perl 
-
-RUN cpan Mozilla::CA \
+      libxml-xslt-perl \
+  && cpan Mozilla::CA \
   && cpan Unicode::Diacritic::Strip \
   && cpan Net::Z3950::PQF \
   && cpan Net::Z3950::ZOOM \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM debian:trixie AS base
 
 WORKDIR /usr/src/app
 
-RUN  apt-get update \
-  && apt-get install -y \
+RUN  rm -rf /var/lib/apt/lists/* \
+  && apt clean \
+  && apt update \
+  && apt install -y \
       apt-transport-https \
       ca-certificates \
       gnupg \
@@ -12,9 +14,11 @@ RUN  apt-get update \
 RUN mkdir -p /etc/apt/keyrings \
   && wget https://ftp.indexdata.com/debian/indexdata.asc -O /etc/apt/keyrings/indexdata.asc \
   && echo 'deb [signed-by=/etc/apt/keyrings/indexdata.asc] https://download.indexdata.com/debian trixie main' > /etc/apt/sources.list.d/indexdata.list \
-  && apt-get update \
-  # && apt-get upgrade -y \
-  && apt-get install -y \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt clean \
+  && apt update \
+  # && apt upgrade -y \
+  && apt install -y \
       build-essential \
       gcc \
       libexpat1-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,13 @@ RUN  apt-get update \
       apt-transport-https \
       ca-certificates \
       gnupg \
-      wget \
-  && mkdir -p /etc/apt/keyrings \
+      wget
+
+RUN mkdir -p /etc/apt/keyrings \
   && wget https://ftp.indexdata.com/debian/indexdata.asc -O /etc/apt/keyrings/indexdata.asc \
-  && echo 'deb [signed-by=/etc/apt/keyrings/indexdata.asc] https://ftp.indexdata.com/debian trixie main' > /etc/apt/sources.list.d/indexdata.list \
+  && echo 'deb [signed-by=/etc/apt/keyrings/indexdata.asc] https://download.indexdata.com/debian trixie main' > /etc/apt/sources.list.d/indexdata.list \
   && apt-get update \
-  && apt-get upgrade -y \
+  # && apt-get upgrade -y \
   && apt-get install -y \
       build-essential \
       gcc \
@@ -29,8 +30,9 @@ RUN  apt-get update \
       libdatetime-perl \
       libmarc-record-perl \
       libtest-differences-perl \
-      libxml-xslt-perl \
-  && cpan Mozilla::CA \
+      libxml-xslt-perl 
+
+RUN cpan Mozilla::CA \
   && cpan Unicode::Diacritic::Strip \
   && cpan Net::Z3950::PQF \
   && cpan Net::Z3950::ZOOM \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
 
   agent {
     node {
-      label 'jenkins-agent-java17'
+      label 'jenkins-agent-java17z'
     }
   }
 

--- a/lib/Net/Z3950/FOLIO/MARCHoldings.pm
+++ b/lib/Net/Z3950/FOLIO/MARCHoldings.pm
@@ -13,8 +13,13 @@ sub insertMARCHoldings {
         my $holdingsMap = _listOfPairs2map($holdingsObjects->[$i]);
 	my $itemObjects = $holdingsMap->{circulations};
 	my $marcField;
-	my $nitems = 0;
 
+	if (scalar @$itemObjects == 0) {
+	    # Special case: we have holdings information, but no associated items
+	    $marcField = _addSubfields($marcField, $marcCfg, $marcCfg->{holdingsElements}, $holdingsMap);
+	}
+
+	my $nitems = 0;
 	for (my $j = 0; $j < @$itemObjects; $j++) {
 	    my $itemMap = _listOfPairs2map($itemObjects->[$j]);
 	    next if $marcCfg->{restrictToItem} && $barcode && $itemMap->{itemId} ne $barcode;

--- a/t/06-marc-holdings.t
+++ b/t/06-marc-holdings.t
@@ -9,12 +9,13 @@ use DummyRecord;
 BEGIN {
     use vars qw(@tests);
     @tests = (
-	# testName, configName1, configName2
-	[ '[regular]', undef ],
-	[ 'fieldPerItem', 'fieldPerItem' ],
-	[ 'restrictToItem', 'restrictToItem' ],
-	[ 'holdingsInEachItem', 'holdingsInEachItem' ],
-	[ 'fieldPerItem with holdings', 'fieldPerItem', 'holdingsInEachItem' ],
+	# testName, inputRecord, configName1, configName2
+	[ '[regular]', 1, undef ],
+	[ 'fieldPerItem', 1, 'fieldPerItem' ],
+	[ 'restrictToItem', 1, 'restrictToItem' ],
+	[ 'holdingsInEachItem', 1, 'holdingsInEachItem' ],
+	[ 'fieldPerItem with holdings', 1, 'fieldPerItem', 'holdingsInEachItem' ],
+	[ 'no items in holdings', 4 ],
     );
 }
 
@@ -22,21 +23,19 @@ use Test::More tests => 1 + scalar(@tests);
 
 BEGIN { use_ok('Net::Z3950::FOLIO') };
 
-for (my $i = 1; $i <= 1; $i++) {
-    foreach my $test (@tests) {
-	my($testName, $configName1, $configName2) = @$test;
+foreach my $test (@tests) {
+    my($testName, $inputRecord, $configName1, $configName2) = @$test;
 
-	my $cfg = new Net::Z3950::FOLIO::Config('t/data/config/foo', 'marcHoldings', $configName1, $configName2);
-	#use Data::Dumper; $Data::Dumper::INDENT = 2; warn "config", Dumper($cfg);
-	my $dummyMarc = makeDummyMarc();
-	my $expected = readFile("t/data/records/expectedMarc$i" . ($configName1 || "") . ($configName2 || "") . ".marc");
-	my $folioJson = readFile("t/data/records/input$i.json");
-	my $folioHoldings = decode_json(qq[{ "holdingsRecords2": $folioJson }]);
-	my $rec = new DummyRecord($folioHoldings, $dummyMarc);
-	insertMARCHoldings($rec, $dummyMarc, $cfg, '9876543210');
-	my $marcString = $dummyMarc->as_formatted() . "\n";
-	is($marcString, $expected, "generated holdings $i: $testName match expected MARC");
-    }
+    my $cfg = new Net::Z3950::FOLIO::Config('t/data/config/foo', 'marcHoldings', $configName1, $configName2);
+    #use Data::Dumper; $Data::Dumper::INDENT = 2; warn "config", Dumper($cfg);
+    my $dummyMarc = makeDummyMarc();
+    my $expected = readFile("t/data/records/expectedMarc$inputRecord" . ($configName1 || "") . ($configName2 || "") . ".marc");
+    my $folioJson = readFile("t/data/records/input$inputRecord.json");
+    my $folioHoldings = decode_json(qq[{ "holdingsRecords2": $folioJson }]);
+    my $rec = new DummyRecord($folioHoldings, $dummyMarc);
+    insertMARCHoldings($rec, $dummyMarc, $cfg, '9876543210');
+    my $marcString = $dummyMarc->as_formatted() . "\n";
+    is($marcString, $expected, "generated holdings $inputRecord: $testName match expected MARC");
 }
 
 

--- a/t/data/records/expectedMarc4.marc
+++ b/t/data/records/expectedMarc4.marc
@@ -1,0 +1,7 @@
+LDR 03101cam a2200505Ii 4500
+007     cr cnu---unuuu
+008     1234567890123456789012345678901
+845    _3Bituminous Coal Division and National Bituminous Coal Commission Records
+       _a"No information obtained from a producer disclosing cost of production or sales realization shall be made public without the consent of the producer from whom the same shall have been obtained";
+       _c50 Stat.88.
+952    _t3

--- a/t/data/records/input4.json
+++ b/t/data/records/input4.json
@@ -1,0 +1,54 @@
+[
+  {
+    "acquisitionFormat": null,
+    "acquisitionMethod": null,
+    "callNumber": "G1046.C3 .L56 2009eb",
+    "callNumberPrefix": null,
+    "callNumberSuffix": null,
+    "callNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+    "copyNumber": 3,
+    "digitizationPolicy": null,
+    "discoverySuppress": null,
+    "electronicAccess": [
+      {
+        "linkText": null,
+        "materialsSpecification": null,
+        "publicNote": "Access E-Book",
+        "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+        "uri": "https://ezproxy.simmons.edu/login?url=http://www.jstor.org/stable/10.2307/j.ctt24hc08"
+      }
+    ],
+    "formerIds": [],
+    "bareHoldingsItems": [],
+    "holdingsStatements": [],
+    "holdingsStatementsForIndexes": [],
+    "holdingsStatementsForSupplements": [],
+    "holdingsTypeId": null,
+    "hrid": "b2245518-elere",
+    "id": "697448a8-a428-11ea-b7fc-94e55e224816",
+    "illPolicyId": null,
+    "instanceId": "2ff48cb6-a41c-11ea-8d99-9ee25e224816",
+    "metadata": null,
+    "notes": [
+      {
+        "holdingsNoteType": {
+          "id": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+          "name": "Public",
+          "source": "folio"
+        },
+        "holdingsNoteTypeId": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+        "note": "All Cretans are liars",
+        "staffOnly": false
+      }
+    ],
+    "numberOfItems": null,
+    "permanentLocation": null,
+    "permanentLocationId": "b681f0f3-c5d3-434f-8c15-db3d8b074c43",
+    "receiptStatus": null,
+    "receivingHistory": null,
+    "retentionPolicy": null,
+    "shelvingTitle": "The Amazing Adventures of Captain Gladys \"Stoat\" Pamphlet and Her Intrepid Spaniel Stig Among the Giant Pygmies of Beccles",
+    "statisticalCodeIds": [],
+    "temporaryLocationId": null
+  }
+]


### PR DESCRIPTION
If a holdings record has no items, generated MARC holdings still includes holdings fields. Fixes a regression.