### PR TITLE
Release v4.4.1

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Revision history for Perl extension Net::Z3950::FOLIO.
 
+## 4.4.1 (Thu 30 Apr 2026 13:06:47 BST)
+
+* Re-release of v4.4.0, because I somehow left the old version number v4.3.0 in that release. This time it's 4.4.1. Thanks to Michelle Suranofsky for spotting this in the comments to ZF-122.
+
 ## 4.4.0 (Thu 16 Apr 2026 18:06:42 BST)
 
 * Add holdings `hrid` to the GraphQL query. (Related to ZF-114.)

--- a/lib/Net/Z3950/FOLIO.pm
+++ b/lib/Net/Z3950/FOLIO.pm
@@ -20,7 +20,7 @@ use Net::Z3950::FOLIO::RPN;
 use Net::Z3950::FOLIO::SurrogateDiagnostic;
 
 
-our $VERSION = 'v4.4.0';
+our $VERSION = 'v4.4.1';
 
 
 sub FORMAT_USMARC { '1.2.840.10003.5.10' }


### PR DESCRIPTION
* Re-release of v4.4.0, because I somehow left the old version number v4.3.0 in that release. This time it's 4.4.1. Thanks to Michelle Suranofsky for spotting this in the comments to ZF-122.